### PR TITLE
MEMSTATUSEX undefined on MinGW by default

### DIFF
--- a/devIocStats/os/WIN32/osdMemUsage.c
+++ b/devIocStats/os/WIN32/osdMemUsage.c
@@ -16,11 +16,17 @@
  *  Author: Ralph Lange (HZB/BESSY)
  *
  *  Modification History
+ *  2015-10-22 Keenan Lang (APS)
  *  2012-03-16 Helge Brands (PSI)
  *  2009-05-13 Ralph Lange (HZB/BESSY)
  *     Restructured OSD parts
  *
  */
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define WINVER 0x0500
+#endif
+
 #include <windows.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
As per a notice in windef.h, MinGW doesn't define MEMSTATUSEX by default and instead requires the macro WINVER to be set above a certain amount.