### PR TITLE
Replaced the number of processors value in sysconf

### DIFF
--- a/devIocStats/os/Darwin/devIocStatsOSD.h
+++ b/devIocStats/os/Darwin/devIocStatsOSD.h
@@ -18,7 +18,9 @@
  *     Minor modificaction to Ralph Lange's posix version
  *  2010-07-14  Ralph Lange (HZB/BESSY)
  *     Added CPU Utilization (IOC load), number of CPUs
- *
+ *  2016-02-25  Jeong Han Lee (ESS)
+ *     Replaced _SC_NPROCESSORS_CONF with _SC_NPROCESSORS_ONLN
+ */
  */
 
 #include <string.h>
@@ -31,7 +33,7 @@ static char *sysBootLine = "<not implemented>";
 #define FDTABLE_INUSE(i) (0)
 #define MAX_FILES 0
 #define CLUSTSIZES 2
-#define NO_OF_CPUS sysconf(_SC_NPROCESSORS_CONF)
+#define NO_OF_CPUS sysconf(_SC_NPROCESSORS_ONLN)
 #define TICKS_PER_SEC sysconf(_SC_CLK_TCK)
 
 #include <sys/reboot.h>

--- a/devIocStats/os/posix/devIocStatsOSD.h
+++ b/devIocStats/os/posix/devIocStatsOSD.h
@@ -20,7 +20,8 @@
  *     Restructured OSD parts
  *  2010-07-14  Ralph Lange (HZB/BESSY)
  *     Added CPU Utilization (IOC load), number of CPUs
- *
+ *  2016-02-25  Jeong Han Lee (ESS)
+ *     Replaced _SC_NPROCESSORS_CONF with _SC_NPROCESSORS_ONLN
  */
 
 #include <string.h>
@@ -36,5 +37,5 @@ static char *sysBootLine = "<not implemented>";
 #define MAX_FILES 0
 #define CLUSTSIZES 2
 #define reboot(x) epicsExit(0)
-#define NO_OF_CPUS sysconf(_SC_NPROCESSORS_CONF)
+#define NO_OF_CPUS sysconf(_SC_NPROCESSORS_ONLN)
 #define TICKS_PER_SEC sysconf(_SC_CLK_TCK)


### PR DESCRIPTION
I replaced _SC_NPROCESSORS_CONF with _SC_NPROCESSORS_ONLN, because sysconf(_SC_NPROCESSORS_ONLN) returns the number of processors which are currently online or available. In most case, this value is more interesting than sysconf(_SC_NPROCESSORS_CONF) which returns the number of processors the operating system configured.

