### PR TITLE
Added the temperature monitoring PV of the Thermal Zone0 

### DIFF
--- a/README_devIocStats
+++ b/README_devIocStats
@@ -1,4 +1,4 @@
-README_devIocStats		Last Updated 04/16/2015
+README_devIocStats		Last Updated 02/25/2016
 ------------------
 
 I - General Notes on devIocStats - All Operating Systems
@@ -108,6 +108,7 @@ Analog In (ai) Records (DTYP = "IOC stats"), INP = @one of the following:
                 workspace_alloc_bytes - number of RAM workspace allocated bytes
                 workspace_free_bytes  - number of RAM workspace free bytes
                 workspace_total_bytes - number of RAM workspace total bytes
+   		sys_zonetemp     - Thermal Zone 0 temperature 
 
 Analog In (ai) Records for Cluster Statistics (RTEMS and vxWorks IOCs only)
 (DTYP = "IOC stats clusts"), INP = @clust_info <pool> <index> <type> where:

--- a/devIocStats/Makefile
+++ b/devIocStats/Makefile
@@ -39,6 +39,7 @@ SRCS += osdBootInfo.c
 SRCS += osdSystemInfo.c
 SRCS += osdHostInfo.c
 SRCS += osdPIDInfo.c
+SRCS += osdSysZoneTemp.c
 
 OBJS_vxWorks += osdCpuUsageTest.o
 

--- a/devIocStats/devIocStats.h
+++ b/devIocStats/devIocStats.h
@@ -65,6 +65,11 @@ typedef struct {
     double iocLoad;
 } loadInfo;
 
+typedef struct {
+  int sysZoneTemp;
+} tempInfo;
+
+
 /* Functions (API) for OSD layer */
 /* All funcs return 0 (OK) / -1 (ERROR) */
 
@@ -118,3 +123,7 @@ extern int devIocStatsGetPwd (char **pval);
 extern int devIocStatsGetHostname (char **pval);
 extern int devIocStatsGetPID (double *proc_id);
 extern int devIocStatsGetPPID (double *proc_id);
+
+/* System Thermal Zone Temperature */
+extern int devIocStatsInitSysZoneTemp (void);
+extern int devIocStatsGetSysZoneTemp (tempInfo *pval);

--- a/devIocStats/os/Linux/osdSysZoneTemp.c
+++ b/devIocStats/os/Linux/osdSysZoneTemp.c
@@ -1,0 +1,38 @@
+/*************************************************************************\
+* Copyright (c) 2009-2010 Helmholtz-Zentrum Berlin
+*     fuer Materialien und Energie GmbH.
+* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2002 The Regents of the University of California, as
+*     Operator of Los Alamos National Laboratory.
+* EPICS BASE Versions 3.13.7
+* and higher are distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/* osdSysZoneTemp.c - Temperature of the themal zone 0 : Linux implementation = use /sys/class/thermal/thermal_zone0/temp  */
+
+/*
+ *  Author: Jeong Han Lee (ESS)
+ *
+ *  Modification History
+ *
+ */
+
+#include <stdio.h>
+#include "devIocStats.h"
+
+int devIocStatsInitSysZoneTemp (void) { return 0; }
+
+int devIocStatsGetSysZoneTemp (tempInfo *pval) {
+  static char statfile[] = "/sys/class/thermal/thermal_zone0/temp";
+  int temp = 0;
+  FILE *fp;
+  fp = fopen(statfile, "r");
+  if (fp) {
+    fscanf(fp, "%d", &temp);
+    fclose(fp);
+  }
+  pval->sysZoneTemp = temp;
+  return 0;
+}

--- a/devIocStats/os/default/osdSysZoneTemp.c
+++ b/devIocStats/os/default/osdSysZoneTemp.c
@@ -1,0 +1,19 @@
+/*************************************************************************\
+* EPICS BASE Versions 3.14.15
+* and higher are distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/* osdSysZoneTemp.c - Temperature of the themal zone 0 : default implementation = do nothing */
+
+/*
+ *  Author: Jeong Han Lee (ESS)
+ *
+ *  Modification History
+ *
+ */
+
+#include "devIocStats.h"
+
+int devIocStatsInitSysZoneTemp (void) { return 0; }
+int devIocStatsGetSysZoneTemp (tempInfo *pval) { return -1; }

--- a/iocAdmin/Db/ioc.template
+++ b/iocAdmin/Db/ioc.template
@@ -361,3 +361,19 @@ record(ai, "$(IOCNAME):PARENT_ID") {
   field(DTYP, "IOC stats")
   field(INP, "@parent_proc_id")
 }
+
+
+
+record(ai, "$(IOCNAME):SYS_ZONE_TEMP") {
+    field(DESC, "System Thermal Zone0 Temperature")
+    field(SCAN, "I/O Intr")
+    field(DTYP, "IOC stats")
+    field( INP, "@sys_zonetemp")
+    field( EGU, "mCelsius")
+    field(LOPR, "0")
+    field(HIHI, "90000")
+    field(HIGH, "80000")
+    field(HHSV, "MAJOR")
+    field( HSV, "MINOR")
+    info(autosaveFields_pass0, "LOPR HIHI HIGH HHSV HSV")
+}


### PR DESCRIPTION
One PV - SYS_ZONE_TEMP- returns the Thermal Zone 0 temperature in a Linux distribution. It uses sysfs in order to get the zone0 temperature via /sys/class/thermal/thermal_zone0/temp. Please see the detailed information at https://www.kernel.org/doc/Documentation/thermal/sysfs-api.txt

This request is the same as the old one https://github.com/epics-modules/iocStats/pull/5, however, I am trying to follow the proper work flow. 

Need to discuss about the unit of the temperature. Here simply copy Ralph's comment as below:

> 
> The unit of the temperature should be something more useful than milli-Celsius. (It's mapped to an ai record, in the end.) I can see two ways to do that:
>  
> -  Easy: Convert to Celsius in the routine that converts from int to double.
> -  Not that easy: Change the code to write the integer into the ai record's RVAL field, and do the linear conversion using the ai record's built-in mechanism. (Remember the device support's return value has to be different for activating the conversion.)
> 
> The second option would allow an easy change between C and F units. (Might be interesting for US users. We should probably have the Fahrenheit conversion factors commented out in the database.)
>  

