### PR TITLE
Changes to work with Linux mingw cross-compiler

### DIFF
--- a/devIocStats/Makefile
+++ b/devIocStats/Makefile
@@ -18,6 +18,7 @@ LIBRARY_IOC = devIocStats
 
 devIocStats_LIBS = $(EPICS_BASE_IOC_LIBS)
 devIocStats_SYS_LIBS_solaris = kstat
+devIocStats_SYS_LIBS_WIN32 += psapi
 
 # OSI parts
 SRCS += devIocStatsAnalog.c

--- a/devIocStats/Makefile
+++ b/devIocStats/Makefile
@@ -28,6 +28,10 @@ SRCS += devIocStatsSub.c
 SRCS += devIocStatsTest.c
 
 # OSD parts
+# Base 3.14 does not correctly define POSIX=NO for mingw
+ifeq (mingw,$(findstring mingw, $(T_A)))
+  POSIX=NO
+endif
 SRCS += osdCpuUsage.c
 SRCS += osdCpuUtilization.c
 SRCS += osdFdUsage.c

--- a/devIocStats/os/WIN32/osdCpuUtilization.c
+++ b/devIocStats/os/WIN32/osdCpuUtilization.c
@@ -28,8 +28,8 @@
 
 //#include <iostream>
 //#include <iomanip>
-#include <Winbase.h>
-#include <Winperf.h>
+#include <winbase.h>
+#include <winperf.h>
 #pragma comment (lib, "Advapi32.lib")
 #include <devIocStats.h>
 

--- a/devIocStats/os/WIN32/osdCpuUtilization.c
+++ b/devIocStats/os/WIN32/osdCpuUtilization.c
@@ -20,6 +20,11 @@
  *  2012-03-16 Helge Brands (PSI) 
  *
  */
+
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define WINVER 0x0501
+#endif
+
 #include <windows.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/devIocStats/os/WIN32/osdFdUsage.c
+++ b/devIocStats/os/WIN32/osdFdUsage.c
@@ -22,6 +22,10 @@
  *
  */
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#define WINVER 0x0501
+#endif
+
 #include <devIocStats.h>
 #include <windows.h>
 #include <stdio.h>

--- a/devIocStats/os/WIN32/osdMemUsage.c
+++ b/devIocStats/os/WIN32/osdMemUsage.c
@@ -21,10 +21,13 @@
  *     Restructured OSD parts
  *
  */
+/* MEMORYSTATUSEX is only defined on XP and later so we only build for that */
+#define _WIN32_WINNT 0x501
 #include <windows.h>
+#include <winbase.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <Psapi.h>
+#include <psapi.h>
 #pragma comment (lib, "Psapi.lib")
 
 

--- a/devIocStats/os/WIN32/osdMemUsage.c
+++ b/devIocStats/os/WIN32/osdMemUsage.c
@@ -24,7 +24,7 @@
  */
 
 #if defined(__MINGW32__) || defined(__MINGW64__)
-#define WINVER 0x0500
+#define WINVER 0x0501
 #endif
 
 #include <windows.h>

--- a/devIocStats/os/WIN32/osdSystemInfo.c
+++ b/devIocStats/os/WIN32/osdSystemInfo.c
@@ -23,7 +23,7 @@
  */
 
 #include <windows.h>
-#include <epicsstdio.h>
+#include <epicsStdio.h>
 #include <devIocStats.h>
 
 static char* versionstring;

--- a/iocAdmin/srcDisplay/Makefile
+++ b/iocAdmin/srcDisplay/Makefile
@@ -10,9 +10,10 @@ EDL += ioc_stats_epics_env.edl
 EDL += ioc_stats_limits.edl
 EDL += ioc_stats_reboot_confirm.edl
 EDL += ioc_stats_release.edl
+EDL += ioc_stats_reloadacf_confirm.edl
+EDL += ioc_stats_scanmon.edl
 EDL += ioc_stats_soft.edl
 EDL += ioc_stats_vxworks.edl
-EDL += ioc_stats_scanmon.edl
 
 include $(TOP)/configure/RULES
 #----------------------------------------


### PR DESCRIPTION
Minor changes to avoid errors and warnings when cross-compiling win32-x86-mingw on Linux.