### PR TITLE
Move MODULE_SITE_TOP definition to the end of the file

### DIFF
--- a/RELEASE_SITE
+++ b/RELEASE_SITE
@@ -10,7 +10,9 @@
 #==============================================================================
 EPICS_SITE_TOP=/usr/local/lcls/epics
 BASE_SITE_TOP=/usr/local/lcls/epics/base
-MODULES_SITE_TOP=/usr/local/lcls/epics/modules/R3-14-12
 IOC_SITE_TOP=/usr/local/lcls/epics/iocTop
 EPICS_BASE_VER=base-R3-14-12
 #==============================================================================
+# This definition goes last due to the build system requiring it to be "close"
+# to its usage in configure/RELEASE
+MODULES_SITE_TOP=/usr/local/lcls/epics/modules/R3-14-12


### PR DESCRIPTION
When building with EPICS 3.16, the following build error appears:

```
This application's RELEASE file(s) define
    EPICS_MODULES = /usr/local/lcls/epics/modules/R3-14-12
after but not adjacent to
    MODULES_SITE_TOP = /usr/local/lcls/epics/modules/R3-14-12
Module definitions that share paths must be grouped together.
Either remove a definition, or move it to a line immediately
above or below the other(s).
Any non-module definitions belong in configure/CONFIG_SITE.
```

This patch deals with the issue by moving the definition to the last
line of the file.
