### PR TITLE
Fixed typo that breaks builds on OS X.

### DIFF
--- a/devIocStats/os/Darwin/devIocStatsOSD.h
+++ b/devIocStats/os/Darwin/devIocStatsOSD.h
@@ -21,7 +21,6 @@
  *  2016-02-25  Jeong Han Lee (ESS)
  *     Replaced _SC_NPROCESSORS_CONF with _SC_NPROCESSORS_ONLN
  */
- */
 
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Fixs #13 