### PR TITLE
Use EPICS_BASE.$(EPICS_HOST_ARCH) if it exists

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -20,5 +20,6 @@ endif
 EPICS_BASE=/afs/slac/g/spear/epics/base
 #EPICS_BASE=/afs/slac/g/lcls/epics/R3-15-1_1-0/base/base-R3-15-1_1-0
 #EPICS_BASE=/afs/slac/g/lcls/epics/R3-16-0/base/base-R3-16-0
+-include $(TOP)/../configure/EPICS_BASE.$(EPICS_HOST_ARCH)
 
 # End of file


### PR DESCRIPTION
Use EPICS_BASE.$(EPICS_HOST_ARCH) from a configure directory that is at the same level as the iocStats directory.  This allows iocStats to work with the new synApps configuration files that allow building for Linux and Windows in the same source tree.

This change should have no effect when the iocStats modules is used outside of synApps.

Fixes #15 
