### PR TITLE
Use epicsExitLater()

### DIFF
--- a/.ci/travis-prepare.sh
+++ b/.ci/travis-prepare.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+set -e -x
+
+cat << EOF > configure/RELEASE
+EPICS_BASE=$HOME/epics-base
+EOF
+
+# use default selection for MSI
+sed -i -e '/MSI/d' configure/CONFIG_SITE
+
+git clone --depth 10 --branch $BASE https://github.com/epics-base/epics-base.git $HOME/epics-base
+
+EPICS_HOST_ARCH=`sh $HOME/epics-base/startup/EpicsHostArch`
+
+case "$STATIC" in
+static)
+    cat << EOF >> "$HOME/epics-base/configure/CONFIG_SITE"
+SHARED_LIBRARIES=NO
+STATIC_BUILD=YES
+EOF
+    ;;
+*) ;;
+esac
+
+case "$CMPLR" in
+clang)
+  echo "Host compiler is clang"
+  cat << EOF >> $HOME/epics-base/configure/os/CONFIG_SITE.Common.$EPICS_HOST_ARCH
+GNU         = NO
+CMPLR_CLASS = clang
+CC          = clang
+CCC         = clang++
+EOF
+  ;;
+*) echo "Host compiler is default";;
+esac
+
+# requires wine and g++-mingw-w64-i686
+if [ "$WINE" = "32" ]
+then
+  echo "Cross mingw32"
+  sed -i -e '/CMPLR_PREFIX/d' $HOME/epics-base/configure/os/CONFIG_SITE.linux-x86.win32-x86-mingw
+  cat << EOF >> $HOME/epics-base/configure/os/CONFIG_SITE.linux-x86.win32-x86-mingw
+CMPLR_PREFIX=i686-w64-mingw32-
+EOF
+  cat << EOF >> $HOME/epics-base/configure/CONFIG_SITE
+CROSS_COMPILER_TARGET_ARCHS+=win32-x86-mingw
+EOF
+fi
+
+# set RTEMS to eg. "4.9" or "4.10"
+if [ -n "$RTEMS" ]
+then
+  echo "Cross RTEMS${RTEMS} for pc386"
+  install -d /home/travis/.cache
+  curl -L "https://github.com/mdavidsaver/rsb/releases/download/travis-20160306-2/rtems${RTEMS}-i386-trusty-20190306-2.tar.gz" \
+  | tar -C /home/travis/.cache -xj
+
+  sed -i -e '/^RTEMS_VERSION/d' -e '/^RTEMS_BASE/d' $HOME/epics-base/configure/os/CONFIG_SITE.Common.RTEMS
+  cat << EOF >> $HOME/epics-base/configure/os/CONFIG_SITE.Common.RTEMS
+RTEMS_VERSION=$RTEMS
+RTEMS_BASE=/home/travis/.cache/rtems${RTEMS}-i386
+EOF
+  cat << EOF >> $HOME/epics-base/configure/CONFIG_SITE
+CROSS_COMPILER_TARGET_ARCHS+=RTEMS-pc386
+EOF
+
+fi
+
+make -C "$HOME/epics-base" -j2
+
+# get MSI for 3.14
+case "$BASE" in
+3.14*)
+    echo "Build MSI"
+    install -d "$HOME/msi/extensions/src"
+    
+    curl https://www.aps.anl.gov/epics/download/extensions/extensionsTop_20120904.tar.gz | tar -C "$HOME/msi" -xvz
+
+    curl https://www.aps.anl.gov/epics/download/extensions/msi1-7.tar.gz | tar -C "$HOME/msi/extensions/src" -xvz
+
+    mv "$HOME/msi/extensions/src/msi1-7" "$HOME/msi/extensions/src/msi"
+
+    cat << EOF > "$HOME/msi/extensions/configure/RELEASE"
+EPICS_BASE=$HOME/epics-base
+EPICS_EXTENSIONS=\$(TOP)
+EOF
+
+    make -C "$HOME/msi/extensions"
+
+    cp "$HOME/msi/extensions/bin/$EPICS_HOST_ARCH/msi" "$HOME/epics-base/bin/$EPICS_HOST_ARCH/"
+
+    echo 'MSI:=$(EPICS_BASE)/bin/$(EPICS_HOST_ARCH)/msi' >> "$HOME/epics-base/configure/CONFIG_SITE"
+
+    cat <<EOF >> configure/CONFIG_SITE
+MSI = \$(EPICS_BASE)/bin/\$(EPICS_HOST_ARCH)/msi
+EOF
+
+  ;;
+*) echo "Use MSI from Base"
+  ;;
+esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+dist: trusty
+language: c
+compiler:
+  - gcc
+addons:
+  apt:
+    packages:
+    - libreadline6-dev
+    - libncurses5-dev
+    - perl
+    - clang
+    - g++-mingw-w64-i686
+env:
+ - BASE=3.16 STATIC=shared CMPLR=clang WINE=32
+ - BASE=3.16 STATIC=shared RTEMS=4.10
+ - BASE=3.16 STATIC=static WINE=32
+ - BASE=3.15 STATIC=shared
+ - BASE=3.14 STATIC=shared
+install: ./.ci/travis-prepare.sh
+script: make -j2

--- a/devIocStats/devIocStats.h
+++ b/devIocStats/devIocStats.h
@@ -18,6 +18,17 @@
  *
  */
 
+#ifndef devIocStats_H
+#define devIocStats_H
+
+#include <epicsVersion.h>
+
+#ifndef VERSION_INT
+#  define VERSION_INT(V,R,M,P) ( ((V)<<24) | ((R)<<16) | ((M)<<8) | (P))
+#  define EPICS_VERSION_INT  VERSION_INT(EPICS_VERSION, EPICS_REVISION, EPICS_MODIFICATION, EPICS_PATCH_LEVEL)
+#endif
+
+
 /* Cluster info pool types */
 #define DATA_POOL 0
 #define SYS_POOL  1
@@ -118,3 +129,5 @@ extern int devIocStatsGetPwd (char **pval);
 extern int devIocStatsGetHostname (char **pval);
 extern int devIocStatsGetPID (double *proc_id);
 extern int devIocStatsGetPPID (double *proc_id);
+
+#endif /* devIocStats_H */

--- a/devIocStats/os/WIN32/devIocStatsOSD.h
+++ b/devIocStats/os/WIN32/devIocStatsOSD.h
@@ -46,12 +46,20 @@
  *              info of 100% free (but 100% of 0 is still 0).
  *
  */
+
+#ifndef devIocStatsOSD_H
+#define devIocStatsOSD_H
+
 #include <string.h>
 #include <stdlib.h>
 
 #include <epicsExit.h>
 
-
-
 #define CLUSTSIZES 2
-#define reboot(x) epicsExit(0)
+#if EPICS_VERSION_INT>=VERSION_INT(3,15,1,0)
+#  define reboot(x) epicsExitLater(0)
+#else
+#  define reboot(x) epicsExit(0)
+#endif
+
+#endif /* devIocStatsOSD_H */

--- a/devIocStats/os/default/devIocStatsOSD.h
+++ b/devIocStats/os/default/devIocStatsOSD.h
@@ -12,6 +12,9 @@
 
 /* devIocStatsOSD.h - Header for OS dependent implementation part */
 
+#ifndef devIocStatsOSD_H
+#define devIocStatsOSD_H
+
 #include <epicsExit.h>
 
 #ifdef SYSBOOTLINE_NEEDED
@@ -22,4 +25,11 @@ static char *sysBootLine = "<not implemented>";
 #define CLUSTSIZES 2
 #define NO_OF_CPUS 1
 #define TICKS_PER_SEC 1
-#define reboot(x) epicsExit(0)
+
+#if EPICS_VERSION_INT>=VERSION_INT(3,15,1,0)
+#  define reboot(x) epicsExitLater(0)
+#else
+#  define reboot(x) epicsExit(0)
+#endif
+
+#endif /* devIocStatsOSD_H */

--- a/devIocStats/os/posix/devIocStatsOSD.h
+++ b/devIocStats/os/posix/devIocStatsOSD.h
@@ -24,6 +24,9 @@
  *     Replaced _SC_NPROCESSORS_CONF with _SC_NPROCESSORS_ONLN
  */
 
+#ifndef devIocStatsOSD_H
+#define devIocStatsOSD_H
+
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -36,6 +39,14 @@ static char *sysBootLine = "<not implemented>";
 #define FDTABLE_INUSE(i) (0)
 #define MAX_FILES 0
 #define CLUSTSIZES 2
-#define reboot(x) epicsExit(0)
 #define NO_OF_CPUS sysconf(_SC_NPROCESSORS_ONLN)
 #define TICKS_PER_SEC sysconf(_SC_CLK_TCK)
+
+#if EPICS_VERSION_INT>=VERSION_INT(3,15,1,0)
+#  define reboot(x) epicsExitLater(0)
+#else
+#  define reboot(x) epicsExit(0)
+#endif
+
+#endif /* devIocStatsOSD_H */
+


### PR DESCRIPTION
Use epicsExitLater() if available.  Prefer to use non-blocking epicsExitLater() to request IOC shutdown.  This will eventually allow for IOCs to halt/join scan and server threads.

epicsExitLater() was added in Base 3.15.1.

Also add header guards, and travis-ci.org configuration for automatic build tests.  https://travis-ci.org/mdavidsaver/iocStats