### PR TITLE
Add Support macro to work with makeReleaseConsistent.pl

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -14,8 +14,8 @@ ifeq '$(MAKE_TEST_IOC_APP)' 'YES'
 SUPPORT=/usr/local/epics/R3.14.11/modules/soft/synApps_5_5/support
 -include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
 
-#SNCSEQ     = $(SUPPORT)/seq-2-0-12
-SNCSEQ = /afs/slac/g/spear/epics/modules/seq/seq
+SNCSEQ     = $(SUPPORT)/seq-2-0-12
+#SNCSEQ = /afs/slac/g/spear/epics/modules/seq/seq
 #SNCSEQ = /afs/slac/g/lcls/epics/R3-15-1_1-0/modules/seq/seq-R2-1-17_1-0
 #SNCSEQ = /afs/slac/g/lcls/epics/R3-16-0/modules/seq/seq-2.2.3
 endif

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -11,7 +11,10 @@ ifeq '$(MAKE_TEST_IOC_APP)' 'YES'
 # Define the version of modules needed by
 # IOC apps or other Support apps - used by testIocStatsApp
 # =============================================================
-#SNCSEQ     = /usr/local/epics/R3.14.11/modules/soft/synApps_5_5/support/seq-2-0-12
+SUPPORT=/usr/local/epics/R3.14.11/modules/soft/synApps_5_5/support
+-include $(TOP)/../configure/SUPPORT.$(EPICS_HOST_ARCH)
+
+#SNCSEQ     = $(SUPPORT)/seq-2-0-12
 SNCSEQ = /afs/slac/g/spear/epics/modules/seq/seq
 #SNCSEQ = /afs/slac/g/lcls/epics/R3-15-1_1-0/modules/seq/seq-R2-1-17_1-0
 #SNCSEQ = /afs/slac/g/lcls/epics/R3-16-0/modules/seq/seq-2.2.3


### PR DESCRIPTION
Adding a macro labeled SUPPORT to iocStats' RELEASE file will allow it to work nicely with synApps' makeReleaseConsistent script which is used to update the RELEASE files of all modules in a directory according to a master RELEASE list. 