### PR TITLE
introduce SEP=: instead of hard-coded : (issues #31)

### DIFF
--- a/iocAdmin/Db/ioc.template
+++ b/iocAdmin/Db/ioc.template
@@ -1,5 +1,5 @@
 # Used by Channel Access Security to determine access to this IOC.
-record(mbbo, "$(IOCNAME):ACCESS")
+record(mbbo, "$(IOCNAME)$(SEP=:)ACCESS")
 {
   field(DESC, "$(IOCNAME) Acc Mode")
   field(PINI, "YES")
@@ -13,35 +13,35 @@ record(mbbo, "$(IOCNAME):ACCESS")
   field(THSV, "MAJOR")
   info(autosaveFields, "VAL")
 }
-record(stringin, "$(IOCNAME):STARTTOD")
+record(stringin, "$(IOCNAME)$(SEP=:)STARTTOD")
 {
     field(DESC, "Time and date of startup")
     field(DTYP, "Soft Timestamp")
     field(PINI, "YES")
     field(INP, "@$(TODFORMAT)")
 }
-record(stringin, "$(IOCNAME):TOD")
+record(stringin, "$(IOCNAME)$(SEP=:)TOD")
 {
     field(DESC, "Current time and date")
     field(DTYP, "Soft Timestamp")
     field(SCAN, "1 second")
     field(INP, "@$(TODFORMAT)")
 }
-record(calcout, "$(IOCNAME):HEARTBEAT")
+record(calcout, "$(IOCNAME)$(SEP=:)HEARTBEAT")
 {
     field(DESC, "1 Hz counter since startup")
     field(CALC, "(A<2147483647)?A+1:1")
     field(SCAN, "1 second")
-    field(INPA, "$(IOCNAME):HEARTBEAT")
+    field(INPA, "$(IOCNAME)$(SEP=:)HEARTBEAT")
 }
 # if autosave is working, START_CNT creates a running count of 
 # number of times the IOC was started.
-record(calcout, "$(IOCNAME):START_CNT")
+record(calcout, "$(IOCNAME)$(SEP=:)START_CNT")
 {
     field(DESC, "Increments at startup")
     field(CALC, "A+1")
     field(PINI, "YES")
-    field(INPA, "$(IOCNAME):START_CNT")
+    field(INPA, "$(IOCNAME)$(SEP=:)START_CNT")
     info(autosaveFields_pass0, "VAL")
 }
 #
@@ -49,23 +49,23 @@ record(calcout, "$(IOCNAME):START_CNT")
 # PV updates the Access Security mechanism dynamically.
 # The .acf file is re-read.
 #
-record( sub, "$(IOCNAME):READACF")
+record( sub, "$(IOCNAME)$(SEP=:)READACF")
 {
     field( DESC, "$(IOCNAME) ACF Update")
     field( INAM, "asSubInit")
     field( SNAM, "asSubProcess")
     field( BRSV, "INVALID")
 }
-record(sub, "$(IOCNAME):SYSRESET")
+record(sub, "$(IOCNAME)$(SEP=:)SYSRESET")
 {
-    alias("$(IOCNAME):SysReset")
+    alias("$(IOCNAME)$(SEP=:)SysReset")
     field(DESC, "IOC Restart" )
     field(SNAM, "rebootProc")
     field(BRSV,"INVALID")
     field(L,"1")
 }
 
-record(ai, "$(IOCNAME):CA_CLNT_CNT") {
+record(ai, "$(IOCNAME)$(SEP=:)CA_CLNT_CNT") {
   field(DESC, "Number of CA Clients")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -78,7 +78,7 @@ record(ai, "$(IOCNAME):CA_CLNT_CNT") {
   info(autosaveFields_pass0, "HOPR LOPR HIHI HIGH LOW LOLO HHSV HSV LSV LLSV")
 }
 
-record(ai, "$(IOCNAME):CA_CONN_CNT") {
+record(ai, "$(IOCNAME)$(SEP=:)CA_CONN_CNT") {
   field(DESC, "Number of CA Connections")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -91,33 +91,33 @@ record(ai, "$(IOCNAME):CA_CONN_CNT") {
   info(autosaveFields_pass0, "HOPR LOPR HIHI HIGH LOW LOLO HHSV HSV LSV LLSV")
 }
 
-record(ai, "$(IOCNAME):RECORD_CNT") {
+record(ai, "$(IOCNAME)$(SEP=:)RECORD_CNT") {
   field(DESC, "Number of Records")
   field(PINI, "YES")
   field(DTYP, "IOC stats")
   field(INP, "@records")
 }
 
-record(ai, "$(IOCNAME):FD_MAX") {
+record(ai, "$(IOCNAME)$(SEP=:)FD_MAX") {
   field(DESC, "Max File Descriptors")
   field(PINI, "YES")
   field(DTYP, "IOC stats")
   field(INP, "@maxfd")
 }
 
-record(ai, "$(IOCNAME):FD_CNT") {
+record(ai, "$(IOCNAME)$(SEP=:)FD_CNT") {
   field(DESC, "Allocated File Descriptors")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
-  field(FLNK, "$(IOCNAME):FD_FREE  PP MS")
+  field(FLNK, "$(IOCNAME)$(SEP=:)FD_FREE  PP MS")
   field(INP, "@fd")
 }
 
-record(calc, "$(IOCNAME):FD_FREE") {
+record(calc, "$(IOCNAME)$(SEP=:)FD_FREE") {
   field(DESC, "Available FDs")
   field(CALC, "B>0?B-A:C")
-  field(INPA, "$(IOCNAME):FD_CNT  NPP MS")
-  field(INPB, "$(IOCNAME):FD_MAX  NPP MS")
+  field(INPA, "$(IOCNAME)$(SEP=:)FD_CNT  NPP MS")
+  field(INPB, "$(IOCNAME)$(SEP=:)FD_MAX  NPP MS")
   field(INPC, "1000")
   field(HOPR, "150")
   field(LOLO, "5")
@@ -127,7 +127,7 @@ record(calc, "$(IOCNAME):FD_FREE") {
   info(autosaveFields_pass0, "HOPR LOPR LOW LOLO LSV LLSV")
 }
 
-record(ai, "$(IOCNAME):SYS_CPU_LOAD") {
+record(ai, "$(IOCNAME)$(SEP=:)SYS_CPU_LOAD") {
   field(DESC, "System CPU Load")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -142,8 +142,8 @@ record(ai, "$(IOCNAME):SYS_CPU_LOAD") {
   info(autosaveFields_pass0, "HOPR LOPR HIHI HIGH LOW LOLO HHSV HSV LSV LLSV")
 }
 
-record(ai, "$(IOCNAME):IOC_CPU_LOAD") {
-  alias("$(IOCNAME):LOAD")
+record(ai, "$(IOCNAME)$(SEP=:)IOC_CPU_LOAD") {
+  alias("$(IOCNAME)$(SEP=:)LOAD")
   field(DESC, "IOC CPU Load")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -158,14 +158,14 @@ record(ai, "$(IOCNAME):IOC_CPU_LOAD") {
   info(autosaveFields_pass0, "HOPR LOPR HIHI HIGH LOW LOLO HHSV HSV LSV LLSV")
 }
 
-record(ai, "$(IOCNAME):CPU_CNT") {
+record(ai, "$(IOCNAME)$(SEP=:)CPU_CNT") {
   field(DESC, "Number of CPUs")
   field(DTYP, "IOC stats")
   field(INP, "@no_of_cpus")
   field(PINI, "YES")
 }
 
-record(ai, "$(IOCNAME):SUSP_TASK_CNT") {
+record(ai, "$(IOCNAME)$(SEP=:)SUSP_TASK_CNT") {
   field(DESC, "Number Suspended Tasks")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -175,7 +175,7 @@ record(ai, "$(IOCNAME):SUSP_TASK_CNT") {
   info(autosaveFields_pass0, "HOPR LOPR HIHI HIGH LOW LOLO HHSV HSV LSV LLSV")
 }
 
-record(ai, "$(IOCNAME):MEM_USED") {
+record(ai, "$(IOCNAME)$(SEP=:)MEM_USED") {
   field(DESC, "Allocated Memory")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -183,7 +183,7 @@ record(ai, "$(IOCNAME):MEM_USED") {
   field(EGU, "byte")
 }
 
-record(ai, "$(IOCNAME):MEM_FREE") {
+record(ai, "$(IOCNAME)$(SEP=:)MEM_FREE") {
   field(DESC, "Free Memory")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -194,7 +194,7 @@ record(ai, "$(IOCNAME):MEM_FREE") {
   info(autosaveFields_pass0, "HOPR LOPR LOW LOLO LSV LLSV")
 }
 
-record(ai, "$(IOCNAME):MEM_MAX") {
+record(ai, "$(IOCNAME)$(SEP=:)MEM_MAX") {
   field(DESC, "Maximum Memory")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -202,7 +202,7 @@ record(ai, "$(IOCNAME):MEM_MAX") {
   field(EGU, "byte")
 }
 
-record(ao, "$(IOCNAME):CA_UPD_TIME") {
+record(ao, "$(IOCNAME)$(SEP=:)CA_UPD_TIME") {
   field(DESC, "CA Check Update Period")
   field(DTYP, "IOC stats")
   field(OUT, "@ca_scan_rate")
@@ -214,7 +214,7 @@ record(ao, "$(IOCNAME):CA_UPD_TIME") {
   field(PINI, "YES")
 }
 
-record(ao, "$(IOCNAME):FD_UPD_TIME") {
+record(ao, "$(IOCNAME)$(SEP=:)FD_UPD_TIME") {
   field(DESC, "FD Check Update Period")
   field(DTYP, "IOC stats")
   field(OUT, "@fd_scan_rate")
@@ -226,7 +226,7 @@ record(ao, "$(IOCNAME):FD_UPD_TIME") {
   field(PINI, "YES")
 }
 
-record(ao, "$(IOCNAME):LOAD_UPD_TIME") {
+record(ao, "$(IOCNAME)$(SEP=:)LOAD_UPD_TIME") {
   field(DESC, "CPU Check Update Period")
   field(DTYP, "IOC stats")
   field(OUT, "@cpu_scan_rate")
@@ -238,7 +238,7 @@ record(ao, "$(IOCNAME):LOAD_UPD_TIME") {
   field(PINI, "YES")
 }
 
-record(ao, "$(IOCNAME):MEM_UPD_TIME") {
+record(ao, "$(IOCNAME)$(SEP=:)MEM_UPD_TIME") {
   field(DESC, "Memory Check Update Period")
   field(DTYP, "IOC stats")
   field(OUT, "@memory_scan_rate")
@@ -250,21 +250,21 @@ record(ao, "$(IOCNAME):MEM_UPD_TIME") {
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):ST_SCRIPT1") {
+record(stringin, "$(IOCNAME)$(SEP=:)ST_SCRIPT1") {
   field(DESC, "Startup Script Part1")
   field(DTYP, "IOC stats")
   field(INP, "@startup_script_1")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):ST_SCRIPT2") {
+record(stringin, "$(IOCNAME)$(SEP=:)ST_SCRIPT2") {
   field(DESC, "Startup Script Part2")
   field(DTYP, "IOC stats")
   field(INP, "@startup_script_2")
   field(PINI, "YES")
 }
 
-record(waveform, "$(IOCNAME):ST_SCRIPT") {
+record(waveform, "$(IOCNAME)$(SEP=:)ST_SCRIPT") {
   field(DESC, "Startup Script")
   field(DTYP, "IOC stats")
   field(INP, "@startup_script")
@@ -273,21 +273,21 @@ record(waveform, "$(IOCNAME):ST_SCRIPT") {
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):KERNEL_VERS") {
+record(stringin, "$(IOCNAME)$(SEP=:)KERNEL_VERS") {
   field(DESC, "Kernel Version")
   field(DTYP, "IOC stats")
   field(INP, "@kernel_ver")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):EPICS_VERS") {
+record(stringin, "$(IOCNAME)$(SEP=:)EPICS_VERS") {
   field(DESC, "EPICS Version")
   field(DTYP, "IOC stats")
   field(INP, "@epics_ver")
   field(PINI, "YES")
 }
 
-record(waveform, "$(IOCNAME):EPICS_VERSION") {
+record(waveform, "$(IOCNAME)$(SEP=:)EPICS_VERSION") {
   field(DESC, "EPICS Version")
   field(DTYP, "IOC stats")
   field(INP, "@epics_ver")
@@ -296,28 +296,28 @@ record(waveform, "$(IOCNAME):EPICS_VERSION") {
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):HOSTNAME") {
+record(stringin, "$(IOCNAME)$(SEP=:)HOSTNAME") {
   field(DESC, "Host Name")
   field(DTYP, "IOC stats")
   field(INP, "@hostname")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):APP_DIR1") {
+record(stringin, "$(IOCNAME)$(SEP=:)APP_DIR1") {
   field(DESC, "Application Directory Part 1")
   field(DTYP, "IOC stats")
   field(INP, "@pwd1")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):APP_DIR2") {
+record(stringin, "$(IOCNAME)$(SEP=:)APP_DIR2") {
   field(DESC, "Application Directory Part 2")
   field(DTYP, "IOC stats")
   field(INP, "@pwd2")
   field(PINI, "YES")
 }
 
-record(waveform, "$(IOCNAME):APP_DIR") {
+record(waveform, "$(IOCNAME)$(SEP=:)APP_DIR") {
   field(DESC, "Application Directory")
   field(DTYP, "IOC stats")
   field(INP, "@pwd")
@@ -326,7 +326,7 @@ record(waveform, "$(IOCNAME):APP_DIR") {
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):UPTIME") {
+record(stringin, "$(IOCNAME)$(SEP=:)UPTIME") {
   field(DESC, "Elapsed Time since Start")
   field(SCAN, "1 second")
   field(DTYP, "IOC stats")
@@ -334,28 +334,28 @@ record(stringin, "$(IOCNAME):UPTIME") {
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):ENGINEER") {
+record(stringin, "$(IOCNAME)$(SEP=:)ENGINEER") {
   field(DESC, "Engineer")
   field(DTYP, "IOC stats")
   field(INP, "@engineer")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):LOCATION") {
+record(stringin, "$(IOCNAME)$(SEP=:)LOCATION") {
   field(DESC, "Location")
   field(DTYP, "IOC stats")
   field(INP, "@location")
   field(PINI, "YES")
 }
 
-record(ai, "$(IOCNAME):PROCESS_ID") {
+record(ai, "$(IOCNAME)$(SEP=:)PROCESS_ID") {
   field(DESC, "Process ID")
   field(PINI, "YES")
   field(DTYP, "IOC stats")
   field(INP, "@proc_id")
 }
 
-record(ai, "$(IOCNAME):PARENT_ID") {
+record(ai, "$(IOCNAME)$(SEP=:)PARENT_ID") {
   field(DESC, "Parent Process ID")
   field(PINI, "YES")
   field(DTYP, "IOC stats")

--- a/iocAdmin/Db/iocCluster.template
+++ b/iocAdmin/Db/iocCluster.template
@@ -1,38 +1,38 @@
-record(ai, "$(IOCNAME):CLUST_$(P)_$(S)_0") {
+record(ai, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_0") {
   field(DESC, "$(TYPE) Size")
   field(DTYP, "IOC stats clusts")
   field(INP, "@clust_info $(P) $(S) 0")
-  field(FLNK, "$(IOCNAME):CLUST_$(P)_$(S)_1")
+  field(FLNK, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_1")
 }
 
-record(ai, "$(IOCNAME):CLUST_$(P)_$(S)_1") {
+record(ai, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_1") {
   field(DESC, "$(TYPE) Clusters")
   field(DTYP, "IOC stats clusts")
   field(INP, "@clust_info $(P) $(S) 1")
-  field(FLNK, "$(IOCNAME):CLUST_$(P)_$(S)_2")
+  field(FLNK, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_2")
 }
 
-record(ai, "$(IOCNAME):CLUST_$(P)_$(S)_2") {
+record(ai, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_2") {
   field(DESC, "$(TYPE) Free")
   field(DTYP, "IOC stats clusts")
   field(INP, "@clust_info $(P) $(S) 2")
-  field(FLNK, "$(IOCNAME):CLUST_$(P)_$(S)_3")
+  field(FLNK, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_3")
 }
 
-record(ai, "$(IOCNAME):CLUST_$(P)_$(S)_3") {
+record(ai, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_3") {
   field(DESC, "$(TYPE) Usage")
   field(DTYP, "IOC stats clusts")
   field(INP, "@clust_info $(P) $(S) 3")
-  field(FLNK, "$(IOCNAME):$(TYPE)_CLUST_AVAIL_$(S)")
+  field(FLNK, "$(IOCNAME)$(SEP=:)$(TYPE)_CLUST_AVAIL_$(S)")
 }
 
-record(calc, "$(IOCNAME):$(TYPE)_CLUST_AVAIL_$(S)") {
+record(calc, "$(IOCNAME)$(SEP=:)$(TYPE)_CLUST_AVAIL_$(S)") {
   field(DESC, "$(TYPE) Free percentage")
   field(EGU,  "%")
   field(PREC, "2")
   field(CALC, "A>0?(B/A)*100:B=0?0:-1")
-  field(INPA, "$(IOCNAME):CLUST_$(P)_$(S)_1 MS")
-  field(INPB, "$(IOCNAME):CLUST_$(P)_$(S)_2 MS")
+  field(INPA, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_1 MS")
+  field(INPB, "$(IOCNAME)$(SEP=:)CLUST_$(P)_$(S)_2 MS")
   field(LOLO, "-0.1")
   field(LLSV, "INVALID")
   field(FLNK, "$(FLNK)")

--- a/iocAdmin/Db/iocEnvVar.template
+++ b/iocAdmin/Db/iocEnvVar.template
@@ -1,4 +1,4 @@
-record(stringin, "$(IOCNAME):$(ENVNAME)") {
+record(stringin, "$(IOCNAME)$(SEP=:)$(ENVNAME)") {
   field(DESC, "$(ENVVAR)")
   field(DTYP, "IOC $(ENVTYPE) var")
   field(INP, "@$(ENVVAR)")

--- a/iocAdmin/Db/iocGeneralTime.template
+++ b/iocAdmin/Db/iocGeneralTime.template
@@ -1,4 +1,4 @@
-record(ai, "$(IOCNAME):GTIM_TIME") {
+record(ai, "$(IOCNAME)$(SEP=:)GTIM_TIME") {
   field(DESC, "Gen Time Secs since 1990")
   field(SCAN, "1 second")
   field(DTYP, "General Time")
@@ -7,7 +7,7 @@ record(ai, "$(IOCNAME):GTIM_TIME") {
   field(EGU,  "sec")
 }
 
-record(bo, "$(IOCNAME):GTIM_RESET") {
+record(bo, "$(IOCNAME)$(SEP=:)GTIM_RESET") {
   field(DESC, "Gen Time Error Reset")
   field(DTYP, "General Time")
   field(OUT,  "@RSTERRCNT")
@@ -15,7 +15,7 @@ record(bo, "$(IOCNAME):GTIM_RESET") {
   field(ONAM, "Reset")
 }
 
-record(longin, "$(IOCNAME):GTIM_ERR_CNT") {
+record(longin, "$(IOCNAME)$(SEP=:)GTIM_ERR_CNT") {
   field(DESC, "Gen Time Error Count")
   field(DTYP, "General Time")
   field(INP,  "@GETERRCNT")
@@ -24,21 +24,21 @@ record(longin, "$(IOCNAME):GTIM_ERR_CNT") {
   field(HHSV, "MAJOR")
 }
 
-record(stringin, "$(IOCNAME):GTIM_CUR_SRC") {
+record(stringin, "$(IOCNAME)$(SEP=:)GTIM_CUR_SRC") {
   field(DESC, "Gen Time Current Provider")
   field(DTYP, "General Time")
   field(INP,  "@BESTTCP")
   field(SCAN, "1 second")
 }
 
-record(stringin, "$(IOCNAME):GTIM_EVT_SRC") {
+record(stringin, "$(IOCNAME)$(SEP=:)GTIM_EVT_SRC") {
   field(DESC, "Gen Time Event Provider")
   field(DTYP, "General Time")
   field(INP,  "@BESTTEP")
   field(SCAN, "1 second")
 }
 
-record(stringin, "$(IOCNAME):GTIM_HI_SRC") {
+record(stringin, "$(IOCNAME)$(SEP=:)GTIM_HI_SRC") {
   field(DESC, "Gen Time Highest Provider")
   field(DTYP, "General Time")
   field(INP,  "@TOPTCP")

--- a/iocAdmin/Db/iocRTEMSOnly.template
+++ b/iocAdmin/Db/iocRTEMSOnly.template
@@ -1,4 +1,4 @@
-record(ai, "$(IOCNAME):RAM_WS_USED") {
+record(ai, "$(IOCNAME)$(SEP=:)RAM_WS_USED") {
   field(DESC, "Workspace Allocated Memory")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -6,7 +6,7 @@ record(ai, "$(IOCNAME):RAM_WS_USED") {
   field(EGU, "byte")
 }
 
-record(ai, "$(IOCNAME):RAM_WS_FREE") {
+record(ai, "$(IOCNAME)$(SEP=:)RAM_WS_FREE") {
   field(DESC, "Workspace Free Memory")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
@@ -16,7 +16,7 @@ record(ai, "$(IOCNAME):RAM_WS_FREE") {
   field(LSV, "MINOR")
 }
 
-record(ai, "$(IOCNAME):RAM_WS_MAX") {
+record(ai, "$(IOCNAME)$(SEP=:)RAM_WS_MAX") {
   field(DESC, "Workspace Maximum Memory")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")

--- a/iocAdmin/Db/iocRTOS.template
+++ b/iocAdmin/Db/iocRTOS.template
@@ -1,17 +1,17 @@
-record(ai, "$(IOCNAME):MEM_BLK") {
+record(ai, "$(IOCNAME)$(SEP=:)MEM_BLK") {
   field(DESC, "Maximum Free Memory Block")
   field(SCAN, "I/O Intr")
   field(DTYP, "IOC stats")
   field(INP, "@max_free")
   field(EGU, "byte")
   field(HOPR, "50000000")
-  field(FLNK, "$(IOCNAME):MEM_BLK_FREE  PP MS")
+  field(FLNK, "$(IOCNAME)$(SEP=:)MEM_BLK_FREE  PP MS")
 }
 
-record(calc, "$(IOCNAME):MEM_BLK_FREE") {
+record(calc, "$(IOCNAME)$(SEP=:)MEM_BLK_FREE") {
   field(DESC, "Maximum Free Memory Block")
   field(CALC, "A>0?A:B")
-  field(INPA, "$(IOCNAME):MEM_BLK  NPP MS")
+  field(INPA, "$(IOCNAME)$(SEP=:)MEM_BLK  NPP MS")
   field(INPB, "1000000000")
   field(EGU, "byte")
   field(HOPR, "50000000")
@@ -22,49 +22,49 @@ record(calc, "$(IOCNAME):MEM_BLK_FREE") {
   info(autosaveFields_pass0, "HOPR LOLO LOW LLSV LSV")
 }
 
-record(stringin, "$(IOCNAME):BOOTLINE1") {
+record(stringin, "$(IOCNAME)$(SEP=:)BOOTLINE1") {
   field(DESC, "Boot Line Part1")
   field(DTYP, "IOC stats")
   field(INP, "@bootline_1")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):BOOTLINE2") {
+record(stringin, "$(IOCNAME)$(SEP=:)BOOTLINE2") {
   field(DESC, "Boot Line Part2")
   field(DTYP, "IOC stats")
   field(INP, "@bootline_2")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):BOOTLINE3") {
+record(stringin, "$(IOCNAME)$(SEP=:)BOOTLINE3") {
   field(DESC, "Boot Line Part3")
   field(DTYP, "IOC stats")
   field(INP, "@bootline_3")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):BOOTLINE4") {
+record(stringin, "$(IOCNAME)$(SEP=:)BOOTLINE4") {
   field(DESC, "Boot Line Part4")
   field(DTYP, "IOC stats")
   field(INP, "@bootline_4")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):BOOTLINE5") {
+record(stringin, "$(IOCNAME)$(SEP=:)BOOTLINE5") {
   field(DESC, "Boot Line Part5")
   field(DTYP, "IOC stats")
   field(INP, "@bootline_5")
   field(PINI, "YES")
 }
 
-record(stringin, "$(IOCNAME):BOOTLINE6") {
+record(stringin, "$(IOCNAME)$(SEP=:)BOOTLINE6") {
   field(DESC, "Boot Line Part6")
   field(DTYP, "IOC stats")
   field(INP, "@bootline_6")
   field(PINI, "YES")
 }
 
-record(waveform, "$(IOCNAME):BOOTLINE") {
+record(waveform, "$(IOCNAME)$(SEP=:)BOOTLINE") {
   field(DESC, "Boot Line")
   field(DTYP, "IOC stats")
   field(INP, "@bootline")
@@ -73,7 +73,7 @@ record(waveform, "$(IOCNAME):BOOTLINE") {
   field(PINI, "YES")
 }
 
-record(ai, "$(IOCNAME):SYS_MBUF_FREE") {
+record(ai, "$(IOCNAME)$(SEP=:)SYS_MBUF_FREE") {
   field(DESC, "Min % Free Sys MBUFs")
   field(DTYP, "IOC stats")
   field(SCAN, "I/O Intr")
@@ -83,14 +83,14 @@ record(ai, "$(IOCNAME):SYS_MBUF_FREE") {
   info(autosaveFields_pass0, "LOLO LOW LLSV LSV")
 }
 
-record(ai, "$(IOCNAME):SYS_MBUF_MAX") {
+record(ai, "$(IOCNAME)$(SEP=:)SYS_MBUF_MAX") {
   field(DESC, "Number of System MBUFs")
   field(DTYP, "IOC stats")
   field(INP, "@sys_mbuf")
   field(PINI, "YES")
 }
 
-record(ai, "$(IOCNAME):IFI_ERR_CNT") {
+record(ai, "$(IOCNAME)$(SEP=:)IFI_ERR_CNT") {
   field(DESC, "IF Input Errors")
   field(DTYP, "IOC stats")
   field(SCAN, "I/O Intr")
@@ -98,7 +98,7 @@ record(ai, "$(IOCNAME):IFI_ERR_CNT") {
   info(autosaveFields_pass0, "HIHI HIGH HHSV HSV")
 }
 
-record(ai, "$(IOCNAME):IFO_ERR_CNT") {
+record(ai, "$(IOCNAME)$(SEP=:)IFO_ERR_CNT") {
   field(DESC, "IF Output Errors")
   field(DTYP, "IOC stats")
   field(SCAN, "I/O Intr")

--- a/iocAdmin/Db/iocScanMon.template
+++ b/iocAdmin/Db/iocScanMon.template
@@ -1,11 +1,11 @@
-record(bo, "$(IOCNAME):$(SCANNAME)_MODE") {
+record(bo, "$(IOCNAME)$(SEP=:)$(SCANNAME)_MODE") {
 	field(DESC, "$(SCANNAME) Mode")
 	field(DOL, "$(MODE)")
 	field(PINI, "YES")
 	field(ZNAM, "Relative")
 	field(ONAM, "Absolute")
 }
-record(sub, "$(IOCNAME):$(SCANNAME)_UPD_TIME") {
+record(sub, "$(IOCNAME)$(SEP=:)$(SCANNAME)_UPD_TIME") {
 	field(DESC, "$(SCANNAME) Update Time")
 	field(SCAN, "$(SCAN)")
 	field(EGU, "second")
@@ -19,7 +19,7 @@ record(sub, "$(IOCNAME):$(SCANNAME)_UPD_TIME") {
 	field(LSV, "MINOR")
 	field(LLSV, "MAJOR")
 	field(BRSV, "INVALID")
-	field(INPA, "$(IOCNAME):$(SCANNAME)_MODE")
+	field(INPA, "$(IOCNAME)$(SEP=:)$(SCANNAME)_MODE")
 	field(B,    "$(MINOR_TOL)")
 	field(C,    "$(MAJOR_TOL)")
 }

--- a/iocAdmin/Db/iocScanMonSum.template
+++ b/iocAdmin/Db/iocScanMonSum.template
@@ -1,14 +1,14 @@
 
-record(calc, "$(IOCNAME):SCANMON_SEVR") {
+record(calc, "$(IOCNAME)$(SEP=:)SCANMON_SEVR") {
     field(DESC, "ScanMon Max Severity")
     field(SCAN, "1 second")
     field(CALC, "0")
-    field(INPA, "$(IOCNAME):$(SCANNAME0)_UPD_TIME.SEVR MS")
-    field(INPB, "$(IOCNAME):$(SCANNAME1)_UPD_TIME.SEVR MS")
-    field(INPC, "$(IOCNAME):$(SCANNAME2)_UPD_TIME.SEVR MS")
-    field(INPD, "$(IOCNAME):$(SCANNAME3)_UPD_TIME.SEVR MS")
-    field(INPE, "$(IOCNAME):$(SCANNAME4)_UPD_TIME.SEVR MS")
-    field(INPF, "$(IOCNAME):$(SCANNAME5)_UPD_TIME.SEVR MS")
-    field(INPG, "$(IOCNAME):$(SCANNAME6)_UPD_TIME.SEVR MS")
+    field(INPA, "$(IOCNAME)$(SEP=:)$(SCANNAME0)_UPD_TIME.SEVR MS")
+    field(INPB, "$(IOCNAME)$(SEP=:)$(SCANNAME1)_UPD_TIME.SEVR MS")
+    field(INPC, "$(IOCNAME)$(SEP=:)$(SCANNAME2)_UPD_TIME.SEVR MS")
+    field(INPD, "$(IOCNAME)$(SEP=:)$(SCANNAME3)_UPD_TIME.SEVR MS")
+    field(INPE, "$(IOCNAME)$(SEP=:)$(SCANNAME4)_UPD_TIME.SEVR MS")
+    field(INPF, "$(IOCNAME)$(SEP=:)$(SCANNAME5)_UPD_TIME.SEVR MS")
+    field(INPG, "$(IOCNAME)$(SEP=:)$(SCANNAME6)_UPD_TIME.SEVR MS")
 }
 

--- a/iocAdmin/Db/iocVxWorksOnly.template
+++ b/iocAdmin/Db/iocVxWorksOnly.template
@@ -1,11 +1,11 @@
-record(stringin, "$(IOCNAME):BSP_REV") {
+record(stringin, "$(IOCNAME)$(SEP=:)BSP_REV") {
   field(DESC, "BSP Revision")
   field(DTYP, "IOC stats")
   field(INP, "@bsp_rev")
   field(PINI, "YES")
 }
 
-record(ai, "$(IOCNAME):DAT_MBUF_FREE") {
+record(ai, "$(IOCNAME)$(SEP=:)DAT_MBUF_FREE") {
   field(DESC, "Min % Free Data MBUFs")
   field(DTYP, "IOC stats")
   field(SCAN, "I/O Intr")
@@ -17,7 +17,7 @@ record(ai, "$(IOCNAME):DAT_MBUF_FREE") {
   info(autosaveFields_pass0, "LOLO LOW LLSV LSV")
 }
 
-record(ai, "$(IOCNAME):DAT_MBUF_MAX") {
+record(ai, "$(IOCNAME)$(SEP=:)DAT_MBUF_MAX") {
   field(DESC, "Number of Data MBUFs")
   field(DTYP, "IOC stats")
   field(INP, "@data_mbuf")


### PR DESCRIPTION
Pre-discussion at issues #31 

@anjohnson  

Please review changes in all template files. It doesn't change any others db files from community substitution files.  At ESS, I've create the iocAdminSoft-ess.sustitutions in separated repository [(e3-iocStats)]( https://raw.githubusercontent.com/icshwi/e3-iocStats/master/template/iocAdminSoft-ess.substitutions )

This changes give us to use the our own naming conventions strictly. 

@MarkRivers 

I am sorry about not changing any opi screens, since these changes allow me to follow the ESS naming conventions with the customized ess substitutions file. Once ESS have "bob" screen, I will update it. 


