### PR TITLE
Add pva and cas env

### DIFF
--- a/devIocStats/devIocStatsString.c
+++ b/devIocStats/devIocStatsString.c
@@ -12,23 +12,23 @@
 /* devIocStatsString.c - String Device Support Routines for IOC statistics - based on */
 /* devVXStats.c - Device Support Routines for vxWorks statistics */
 /*
- *	Author: Jim Kowalkowski
- *	Date:  2/1/96
+ *      Author: Jim Kowalkowski
+ *      Date:  2/1/96
  *
  * Modifications at LBNL:
  * -----------------
- * 	97-11-21	SRJ	Added reports of max free mem block,
- *				Channel Access connections and CA clients.
- *				Repaired "artificial load" function.
- *	98-01-28	SRJ	Changes per M. Kraimer's devVXStats of 97-11-19:
- *				explicitly reports file descriptors used;
- *				uses Kraimer's method for CPU load average;
- *				some code simplification and name changes.
+ *      97-11-21        SRJ     Added reports of max free mem block,
+ *                              Channel Access connections and CA clients.
+ *                              Repaired "artificial load" function.
+ *      98-01-28        SRJ     Changes per M. Kraimer's devVXStats of 97-11-19:
+ *                              explicitly reports file descriptors used;
+ *                              uses Kraimer's method for CPU load average;
+ *                              some code simplification and name changes.
  *
  * Modifications for SNS at ORNL:
  * -----------------
- *	03-01-29	CAL 	Add stringin device support.
- *	03-05-08	CAL	Add minMBuf
+ *      03-01-29        CAL     Add stringin device support.
+ *      03-05-08        CAL     Add minMBuf
  *
  * Modifications for LCLS/SPEAR at SLAC:
  * ----------------
@@ -43,41 +43,41 @@
  */
 
 /*
-	--------------------------------------------------------------------
-	Note that the valid values for the parm field of the link
-	information are:
+        --------------------------------------------------------------------
+        Note that the valid values for the parm field of the link
+        information are:
 
-	stringin (DTYP = "IOC stats"):
+        stringin (DTYP = "IOC stats"):
 
-		Some values displayed by the string records are
-	 	longer than the 40 char string record length, so multiple 
-		records must be used to display them.
+                Some values displayed by the string records are
+                longer than the 40 char string record length, so multiple 
+                records must be used to display them.
 
-		The supported stringin devices are all static; except for
+                The supported stringin devices are all static; except for
                 up_time, the record only needs to be processed once, for
                 which PINI is convenient.
 
-		startup_script_[12]	-path of startup script (2 records)
-					Default - uses STARTUP and ST_CMD
-					environment variables.
-		bootline_[1-6]		-CPU bootline (6 records)
- 		bsp_rev			-CPU board support package revision
-		kernel_ver		-OS kernel build version
-		epics_ver		-EPICS base version
+                startup_script_[12]     -path of startup script (2 records)
+                                        Default - uses STARTUP and ST_CMD
+                                        environment variables.
+                bootline_[1-6]          -CPU bootline (6 records)
+                bsp_rev                 -CPU board support package revision
+                kernel_ver              -OS kernel build version
+                epics_ver               -EPICS base version
                 engineer                -IOC Engineer
-					Default - uses ENGINEER env var.
+                                        Default - uses ENGINEER env var.
                 location                -IOC Location
-					Default - uses LOCATION env var.
+                                        Default - uses LOCATION env var.
                 hostname                -IOC Host Name from gethostname
                 pwd[1-2]                -IOC Current Working Directory
                                         (2 records) from getcwd
                 up_time                 -IOC Up Time
 
-	stringin (DTYP = "IOC env var"):
+        stringin (DTYP = "IOC env var"):
 
                 <environment variable>
 
-	stringin (DTYP = "IOC epics var"):
+        stringin (DTYP = "IOC epics var"):
 
                 <EPICS environment variable from envDefs.h>
 */
@@ -110,19 +110,19 @@
 
 struct sStats
 {
-	long      number;
-	DEVSUPFUN report;
-	DEVSUPFUN init;
-	DEVSUPFUN init_record;
-	DEVSUPFUN get_ioint_info;
-	DEVSUPFUN read_stringin;
+        long      number;
+        DEVSUPFUN report;
+        DEVSUPFUN init;
+        DEVSUPFUN init_record;
+        DEVSUPFUN get_ioint_info;
+        DEVSUPFUN read_stringin;
 };
 typedef struct sStats sStats;
 
 struct pvtArea
 {
-	int index;
-	int type;
+        int index;
+        int type;
 };
 typedef struct pvtArea pvtArea;
 
@@ -130,9 +130,9 @@ typedef void (*statGetStrFunc)(char*);
 
 struct validGetStrParms
 {
-	char* name;
-	statGetStrFunc func;
-	int type;
+        char* name;
+        statGetStrFunc func;
+        int type;
 };
 typedef struct validGetStrParms validGetStrParms;
 
@@ -166,24 +166,24 @@ static int devIocStatsGetEngineer (char **pval);
 static int devIocStatsGetLocation (char **pval);
 
 static validGetStrParms statsGetStrParms[]={
-	{ "startup_script_1",		statsSScript1,		STATIC_TYPE },
-	{ "startup_script_2",		statsSScript2, 		STATIC_TYPE },
-	{ "bootline_1",			statsBootline1,		STATIC_TYPE },
-	{ "bootline_2",			statsBootline2,		STATIC_TYPE },
-	{ "bootline_3",			statsBootline3,		STATIC_TYPE },
-	{ "bootline_4",			statsBootline4,		STATIC_TYPE },
-	{ "bootline_5",			statsBootline5,		STATIC_TYPE },
-	{ "bootline_6",			statsBootline6,		STATIC_TYPE },
-	{ "bsp_rev",			statsBSPRev, 		STATIC_TYPE },
-	{ "kernel_ver",			statsKernelVer,		STATIC_TYPE },
-	{ "epics_ver",			statsEPICSVer,		STATIC_TYPE },
-	{ "engineer",			statsEngineer,		STATIC_TYPE },
-	{ "location",			statsLocation,		STATIC_TYPE },
-	{ "up_time",			statsUpTime,		STATIC_TYPE },
-        { "hostname",			statsHostName,		STATIC_TYPE },
-        { "pwd1",			statsPwd1,		STATIC_TYPE },
-        { "pwd2",			statsPwd2,		STATIC_TYPE },
-	{ NULL,NULL,0 }
+        { "startup_script_1",           statsSScript1,          STATIC_TYPE },
+        { "startup_script_2",           statsSScript2,          STATIC_TYPE },
+        { "bootline_1",                 statsBootline1,         STATIC_TYPE },
+        { "bootline_2",                 statsBootline2,         STATIC_TYPE },
+        { "bootline_3",                 statsBootline3,         STATIC_TYPE },
+        { "bootline_4",                 statsBootline4,         STATIC_TYPE },
+        { "bootline_5",                 statsBootline5,         STATIC_TYPE },
+        { "bootline_6",                 statsBootline6,         STATIC_TYPE },
+        { "bsp_rev",                    statsBSPRev,            STATIC_TYPE },
+        { "kernel_ver",                 statsKernelVer,         STATIC_TYPE },
+        { "epics_ver",                  statsEPICSVer,          STATIC_TYPE },
+        { "engineer",                   statsEngineer,          STATIC_TYPE },
+        { "location",                   statsLocation,          STATIC_TYPE },
+        { "up_time",                    statsUpTime,            STATIC_TYPE },
+        { "hostname",                   statsHostName,          STATIC_TYPE },
+        { "pwd1",                       statsPwd1,              STATIC_TYPE },
+        { "pwd2",                       statsPwd2,              STATIC_TYPE },
+        { NULL,NULL,0 }
 };
 
 sStats devStringinStats  ={5,NULL,stringin_init,stringin_init_record,NULL,stringin_read};
@@ -216,52 +216,52 @@ static long stringin_init(int pass)
 
 static long stringin_init_record(stringinRecord* pr)
 {
-	int		i;
-	char	*parm;
-	pvtArea	*pvt = NULL;
-	if(pr->inp.type!=INST_IO)
-	{
-		recGblRecordError(S_db_badField,(void*)pr,
-			"devStringinStats (init_record) Illegal INP field");
-		return S_db_badField;
-	}
-	parm = pr->inp.value.instio.string;
-	for(i=0;statsGetStrParms[i].name && pvt==NULL;i++)
-	{
-		if(strcmp(parm,statsGetStrParms[i].name)==0)
-		{
-			pvt=(pvtArea*)malloc(sizeof(pvtArea));
-			pvt->index=i;
-			pvt->type=statsGetStrParms[i].type;
-		}
-	}
-	if(pvt==NULL)
-	{
-		recGblRecordError(S_db_badField,(void*)pr, 
-		   "devStringinStats (init_record) Illegal INP parm field");
-		return S_db_badField;
-	}
+        int             i;
+        char    *parm;
+        pvtArea *pvt = NULL;
+        if(pr->inp.type!=INST_IO)
+        {
+                recGblRecordError(S_db_badField,(void*)pr,
+                        "devStringinStats (init_record) Illegal INP field");
+                return S_db_badField;
+        }
+        parm = pr->inp.value.instio.string;
+        for(i=0;statsGetStrParms[i].name && pvt==NULL;i++)
+        {
+                if(strcmp(parm,statsGetStrParms[i].name)==0)
+                {
+                        pvt=(pvtArea*)malloc(sizeof(pvtArea));
+                        pvt->index=i;
+                        pvt->type=statsGetStrParms[i].type;
+                }
+        }
+        if(pvt==NULL)
+        {
+                recGblRecordError(S_db_badField,(void*)pr, 
+                   "devStringinStats (init_record) Illegal INP parm field");
+                return S_db_badField;
+        }
 
-	pr->dpvt=pvt;
-	return 0;	/* success */
+        pr->dpvt=pvt;
+        return 0;       /* success */
 }
 
 static long envvar_init_record(stringinRecord* pr)
 {
-	if(pr->inp.type!=INST_IO)
-	{
-		recGblRecordError(S_db_badField,(void*)pr,
-			"devStringinEnvVar (init_record) Illegal INP field");
-		return S_db_badField;
-	}
-	pr->dpvt = pr->inp.value.instio.string;
-	if(pr->dpvt==NULL)
-	{
-		recGblRecordError(S_db_badField,(void*)pr, 
-		   "devStringinEnvVar (init_record) Illegal INP parm field");
-		return S_db_badField;
-	}
-	return 0;	/* success */
+        if(pr->inp.type!=INST_IO)
+        {
+                recGblRecordError(S_db_badField,(void*)pr,
+                        "devStringinEnvVar (init_record) Illegal INP field");
+                return S_db_badField;
+        }
+        pr->dpvt = pr->inp.value.instio.string;
+        if(pr->dpvt==NULL)
+        {
+                recGblRecordError(S_db_badField,(void*)pr, 
+                   "devStringinEnvVar (init_record) Illegal INP parm field");
+                return S_db_badField;
+        }
+        return 0;       /* success */
 }
 
 static long epics_init_record(stringinRecord* pr)
@@ -269,8 +269,8 @@ static long epics_init_record(stringinRecord* pr)
         long status;
         const ENV_PARAM **ppParam = env_param_list;
   
-	status = envvar_init_record(pr);
-	if (status) return status;
+        status = envvar_init_record(pr);
+        if (status) return status;
 
         /* Find a match with one of the EPICS env vars */
         while (*ppParam) {
@@ -288,27 +288,27 @@ static long epics_init_record(stringinRecord* pr)
 
 static long stringin_read(stringinRecord* pr)
 {
-	pvtArea* pvt=(pvtArea*)pr->dpvt;
+        pvtArea* pvt=(pvtArea*)pr->dpvt;
 
-	if (!pvt) return S_dev_badInpType;
+        if (!pvt) return S_dev_badInpType;
 
-	statsGetStrParms[pvt->index].func(pr->val);
-	pr->udf=0;
-	return(0);	/* success */
+        statsGetStrParms[pvt->index].func(pr->val);
+        pr->udf=0;
+        return(0);      /* success */
 }
 
 static long envvar_read(stringinRecord* pr)
 {
-	char **envvar = &notavail;
+        char **envvar = &notavail;
         char *buf;
 
-	if (!pr->dpvt) return S_dev_badInpType;
+        if (!pr->dpvt) return S_dev_badInpType;
         
         if ( (buf=getenv((char *)pr->dpvt)) ) envvar = &buf;
         strncpy(pr->val, *envvar, MAX_NAME_SIZE);
         pr->val[MAX_NAME_SIZE]=0; 
-	pr->udf=0;
-	return(0);	/* success */
+        pr->udf=0;
+        return(0);      /* success */
 }
 
 static long epics_read(stringinRecord* pr)
@@ -327,7 +327,7 @@ static long epics_read(stringinRecord* pr)
 #endif
           return(0);
         }
-	return(0);	/* success */
+        return(0);      /* success */
 }
 
 /* -------------------------------------------------------------------- */

--- a/devIocStats/devIocStatsString.c
+++ b/devIocStats/devIocStatsString.c
@@ -282,7 +282,7 @@ static long epics_init_record(stringinRecord* pr)
         }
         pr->dpvt = 0;
         recGblRecordError(S_db_badField,(void*)pr,
-                "devStringinEnvVar (init_record) Illegal INP parm field");
+                "devStringinEpics (init_record) INP field is not an EPICS env var");
         return S_db_badField;
 }
 

--- a/iocAdmin/Db/Makefile
+++ b/iocAdmin/Db/Makefile
@@ -11,6 +11,7 @@ include $(TOP)/configure/CONFIG
 # Create and install (or just install)
 # databases, templates, substitutions like this
 #
+DB += epicsEnvVars.db
 DB += iocAdminScanMon.db
 DB += ioc.db
 DB += iocRTOS.db
@@ -26,9 +27,12 @@ DB += iocAdminVxWorks.db
 DB += iocAdminSoft.db
 DB += iocAdminRTEMS.db
 
-$(INSTALL_DB)/iocAdminRTEMS.db:	$(INSTALL_DB)/iocAdminScanMon.db
-
-$(INSTALL_DB)/iocAdminSoft.db:	$(INSTALL_DB)/iocAdminScanMon.db
+ifdef BASE_7_0
+V4_ENVTYPE=epics
+else
+V4_ENVTYPE=env
+endif
+USR_DBFLAGS += -M V4_ENVTYPE=$(V4_ENVTYPE)
 
 #
 #----------------------------------------------------
@@ -39,4 +43,8 @@ include $(TOP)/configure/RULES
 
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
+
+$(COMMON_DIR)/iocAdminRTEMS.db:	$(INSTALL_DB)/iocAdminScanMon.db $(INSTALL_DB)/epicsEnvVars.db
+
+$(COMMON_DIR)/iocAdminSoft.db:	$(INSTALL_DB)/iocAdminScanMon.db $(INSTALL_DB)/epicsEnvVars.db
 

--- a/iocAdmin/Db/Makefile
+++ b/iocAdmin/Db/Makefile
@@ -11,6 +11,7 @@ include $(TOP)/configure/CONFIG
 # Create and install (or just install)
 # databases, templates, substitutions like this
 #
+DB += iocAdminScanMon.db
 DB += ioc.db
 DB += iocRTOS.db
 DB += iocVxWorksOnly.db
@@ -24,7 +25,10 @@ DB += access.db
 DB += iocAdminVxWorks.db
 DB += iocAdminSoft.db
 DB += iocAdminRTEMS.db
-DB += iocAdminScanMon.db
+
+$(INSTALL_DB)/iocAdminRTEMS.db:	$(INSTALL_DB)/iocAdminScanMon.db
+
+$(INSTALL_DB)/iocAdminSoft.db:	$(INSTALL_DB)/iocAdminScanMon.db
 
 #
 #----------------------------------------------------

--- a/iocAdmin/Db/Makefile
+++ b/iocAdmin/Db/Makefile
@@ -28,11 +28,8 @@ DB += iocAdminSoft.db
 DB += iocAdminRTEMS.db
 
 ifdef BASE_7_0
-V4_ENVTYPE=epics
-else
-V4_ENVTYPE=env
+USR_DBFLAGS += -M V4_ENVTYPE=epics
 endif
-USR_DBFLAGS += -M V4_ENVTYPE=$(V4_ENVTYPE)
 
 #
 #----------------------------------------------------

--- a/iocAdmin/Db/epicsEnvVars.substitutions
+++ b/iocAdmin/Db/epicsEnvVars.substitutions
@@ -1,0 +1,48 @@
+#==============================================================================
+#
+# Abs:  Records for EPICS environment variables
+#
+# Name: epicsEnvVars.substitutions
+#
+#==============================================================================
+#
+file iocEnvVar.template
+{
+    pattern
+    { ENVNAME                    , ENVVAR                          , ENVTYPE}
+    { CA_ADDR_LIST               , EPICS_CA_ADDR_LIST              , epics  } 
+    { CA_CONN_TIME               , EPICS_CA_CONN_TMO               , epics  } 
+    { CA_AUTO_ADDR               , EPICS_CA_AUTO_ADDR_LIST         , epics  }
+    { CA_RPTR_PORT               , EPICS_CA_REPEATER_PORT          , epics  }
+    { CA_SRVR_PORT               , EPICS_CA_SERVER_PORT            , epics  }
+    { CA_MAX_ARRAY               , EPICS_CA_MAX_ARRAY_BYTES        , epics  }
+    { CA_SRCH_TIME               , EPICS_CA_MAX_SEARCH_PERIOD      , epics  }
+    { CA_BEAC_TIME               , EPICS_CA_BEACON_PERIOD          , epics  }
+
+    { CAS_SRVR_PORT              , EPICS_CAS_SERVER_PORT           , epics  }
+    { CAS_AUTO_ADDR              , EPICS_CAS_AUTO_BEACON_ADDR_LIST , epics  }
+    { CAS_ADDR_LIST              , EPICS_CAS_BEACON_ADDR_LIST      , epics  } 
+    { CAS_BEACON_PERIOD          , EPICS_CAS_BEACON_PERIOD         , epics  }
+    { CAS_BEACON_PORT            , EPICS_CAS_BEACON_PORT           , epics  }
+    { CAS_ADDR_INTF_LIST         , EPICS_CAS_INTF_ADDR_LIST        , epics  } 
+    { CAS_ADDR_IGNORE_LIST       , EPICS_CAS_IGNORE_ADDR_LIST      , epics  } 
+
+    { TIMEZONE                   , EPICS_TIMEZONE                  , epics  }
+    { TS_NTP_INET                , EPICS_TS_NTP_INET               , epics  }
+    { IOC_LOG_PORT               , EPICS_IOC_LOG_PORT              , epics  }
+    { IOC_LOG_INET               , EPICS_IOC_LOG_INET              , epics  }
+
+    { PVA_ADDR_LIST              , EPICS_PVA_ADDR_LIST       , $(V4_ENVTYPE)  }
+    { PVA_AUTO_ADDR              , EPICS_PVA_AUTO_ADDR_LIST  , $(V4_ENVTYPE)  }
+    { PVA_BEACON_PERIOD          , EPICS_PVA_BEACON_PERIOD   , $(V4_ENVTYPE)  }
+    { PVA_BROADCAST_PORT         , EPICS_PVA_BROADCAST_PORT  , $(V4_ENVTYPE)  }
+    { PVA_CONN_TMO               , EPICS_PVA_CONN_TMO        , $(V4_ENVTYPE)  }
+    { PVA_DEBUG                  , EPICS_PVA_DEBUG           , $(V4_ENVTYPE)  }
+    { PVA_SERVER_PORT            , EPICS_PVA_SERVER_PORT     , $(V4_ENVTYPE)  }
+
+    { PVAS_AUTO_BEACON_ADDR_LIST, EPICS_PVAS_AUTO_BEACON_ADDR_LIST , $(V4_ENVTYPE)  }
+    { PVAS_BEACON_ADDR_LIST     , EPICS_PVAS_BEACON_ADDR_LIST      , $(V4_ENVTYPE)  }
+    { PVAS_BEACON_PERIOD        , EPICS_PVAS_BEACON_PERIOD         , $(V4_ENVTYPE)  }
+    { PVAS_BROADCAST_PORT       , EPICS_PVAS_BROADCAST_PORT        , $(V4_ENVTYPE)  }
+    { PVAS_SERVER_PORT          , EPICS_PVAS_SERVER_PORT           , $(V4_ENVTYPE)  }
+}

--- a/iocAdmin/Db/epicsEnvVars.substitutions
+++ b/iocAdmin/Db/epicsEnvVars.substitutions
@@ -32,17 +32,17 @@ file iocEnvVar.template
     { IOC_LOG_PORT               , EPICS_IOC_LOG_PORT              , epics  }
     { IOC_LOG_INET               , EPICS_IOC_LOG_INET              , epics  }
 
-    { PVA_ADDR_LIST              , EPICS_PVA_ADDR_LIST       , $(V4_ENVTYPE)  }
-    { PVA_AUTO_ADDR              , EPICS_PVA_AUTO_ADDR_LIST  , $(V4_ENVTYPE)  }
-    { PVA_BEACON_PERIOD          , EPICS_PVA_BEACON_PERIOD   , $(V4_ENVTYPE)  }
-    { PVA_BROADCAST_PORT         , EPICS_PVA_BROADCAST_PORT  , $(V4_ENVTYPE)  }
-    { PVA_CONN_TMO               , EPICS_PVA_CONN_TMO        , $(V4_ENVTYPE)  }
-    { PVA_DEBUG                  , EPICS_PVA_DEBUG           , $(V4_ENVTYPE)  }
-    { PVA_SERVER_PORT            , EPICS_PVA_SERVER_PORT     , $(V4_ENVTYPE)  }
+    { PVA_ADDR_LIST              , EPICS_PVA_ADDR_LIST       , $(V4_ENVTYPE=env)  }
+    { PVA_AUTO_ADDR              , EPICS_PVA_AUTO_ADDR_LIST  , $(V4_ENVTYPE=env)  }
+    { PVA_BEACON_PERIOD          , EPICS_PVA_BEACON_PERIOD   , $(V4_ENVTYPE=env)  }
+    { PVA_BROADCAST_PORT         , EPICS_PVA_BROADCAST_PORT  , $(V4_ENVTYPE=env)  }
+    { PVA_CONN_TMO               , EPICS_PVA_CONN_TMO        , $(V4_ENVTYPE=env)  }
+    { PVA_DEBUG                  , EPICS_PVA_DEBUG           , $(V4_ENVTYPE=env)  }
+    { PVA_SERVER_PORT            , EPICS_PVA_SERVER_PORT     , $(V4_ENVTYPE=env)  }
 
-    { PVAS_AUTO_BEACON_ADDR_LIST, EPICS_PVAS_AUTO_BEACON_ADDR_LIST , $(V4_ENVTYPE)  }
-    { PVAS_BEACON_ADDR_LIST     , EPICS_PVAS_BEACON_ADDR_LIST      , $(V4_ENVTYPE)  }
-    { PVAS_BEACON_PERIOD        , EPICS_PVAS_BEACON_PERIOD         , $(V4_ENVTYPE)  }
-    { PVAS_BROADCAST_PORT       , EPICS_PVAS_BROADCAST_PORT        , $(V4_ENVTYPE)  }
-    { PVAS_SERVER_PORT          , EPICS_PVAS_SERVER_PORT           , $(V4_ENVTYPE)  }
+    { PVAS_AUTO_BEACON_ADDR_LIST, EPICS_PVAS_AUTO_BEACON_ADDR_LIST , $(V4_ENVTYPE=env)  }
+    { PVAS_BEACON_ADDR_LIST     , EPICS_PVAS_BEACON_ADDR_LIST      , $(V4_ENVTYPE=env)  }
+    { PVAS_BEACON_PERIOD        , EPICS_PVAS_BEACON_PERIOD         , $(V4_ENVTYPE=env)  }
+    { PVAS_BROADCAST_PORT       , EPICS_PVAS_BROADCAST_PORT        , $(V4_ENVTYPE=env)  }
+    { PVAS_SERVER_PORT          , EPICS_PVAS_SERVER_PORT           , $(V4_ENVTYPE=env)  }
 }

--- a/iocAdmin/Db/iocAdminRTEMS.substitutions
+++ b/iocAdmin/Db/iocAdminRTEMS.substitutions
@@ -16,6 +16,12 @@ file iocGeneralTime.template
 pattern { IOCNAME }
 	{ "$(IOC)"  }
 }
+file iocAdminScanMon.db
+{
+	pattern
+	{	IOCNAME	 }
+	{	"$(IOC)" }
+}
 file iocRTOS.template
 {
 pattern { IOCNAME , SYS_MBUF_FLNK     }

--- a/iocAdmin/Db/iocAdminRTEMS.substitutions
+++ b/iocAdmin/Db/iocAdminRTEMS.substitutions
@@ -32,7 +32,7 @@ file iocRTEMSOnly.template
 pattern { IOCNAME }
 	{ "$(IOC)"  }
 }
-file iocEnvVar.template
+file epicsEnvVars.db
 {
 pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ "$(IOC)" , CA_ADDR_LIST , EPICS_CA_ADDR_LIST              , epics  } 

--- a/iocAdmin/Db/iocAdminRTEMS.substitutions
+++ b/iocAdmin/Db/iocAdminRTEMS.substitutions
@@ -43,11 +43,32 @@ pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ "$(IOC)" , CA_MAX_ARRAY , EPICS_CA_MAX_ARRAY_BYTES        , epics  }
 	{ "$(IOC)" , CA_SRCH_TIME , EPICS_CA_MAX_SEARCH_PERIOD      , epics  }
 	{ "$(IOC)" , CA_BEAC_TIME , EPICS_CA_BEACON_PERIOD          , epics  }
-	{ "$(IOC)" , TIMEZONE     , EPICS_TIMEZONE                  , epics  }
-	{ "$(IOC)" , TZ           , EPICS_TZ                        , epics  }
-	{ "$(IOC)" , TS_NTP_INET  , EPICS_TS_NTP_INET               , epics  }
-	{ "$(IOC)" , IOC_LOG_PORT , EPICS_IOC_LOG_PORT              , epics  }
-	{ "$(IOC)" , IOC_LOG_INET , EPICS_IOC_LOG_INET              , epics  }
+
+    { "$(IOC)" , CAS_SRVR_PORT        , EPICS_CAS_SERVER_PORT          , epics  }
+    { "$(IOC)" , CAS_AUTO_ADDR        , EPICS_CAS_AUTO_BEACON_ADDR_LIST, epics  }
+    { "$(IOC)" , CAS_ADDR_LIST        , EPICS_CAS_BEACON_ADDR_LIST     , epics  } 
+    { "$(IOC)" , CAS_BEACON_PERIOD    , EPICS_CAS_BEACON_PERIOD        , epics  }
+    { "$(IOC)" , CAS_BEACON_PORT      , EPICS_CAS_BEACON_PORT          , epics  }
+    { "$(IOC)" , CAS_ADDR_INTF_LIST   , EPICS_CAS_INTF_ADDR_LIST       , epics  } 
+    { "$(IOC)" , CAS_ADDR_IGNORE_LIST , EPICS_CAS_IGNORE_ADDR_LIST     , epics  } 
+
+    { "$(IOC)" , TS_NTP_INET  , EPICS_TS_NTP_INET               , epics  }
+    { "$(IOC)" , IOC_LOG_PORT , EPICS_IOC_LOG_PORT              , epics  }
+    { "$(IOC)" , IOC_LOG_INET , EPICS_IOC_LOG_INET              , epics  }
+
+    { "$(IOC)" , PVA_ADDR_LIST ,      EPICS_PVA_ADDR_LIST       , epics  }
+    { "$(IOC)" , PVA_AUTO_ADDR ,      EPICS_PVA_AUTO_ADDR_LIST  , epics  }
+    { "$(IOC)" , PVA_BEACON_PERIOD ,  EPICS_PVA_BEACON_PERIOD   , epics  }
+    { "$(IOC)" , PVA_BROADCAST_PORT , EPICS_PVA_BROADCAST_PORT  , epics  }
+    { "$(IOC)" , PVA_CONN_TMO ,       EPICS_PVA_CONN_TMO        , epics  }
+    { "$(IOC)" , PVA_DEBUG ,          EPICS_PVA_DEBUG           , epics  }
+    { "$(IOC)" , PVA_SERVER_PORT ,    EPICS_PVA_SERVER_PORT     , epics  }
+
+    { "$(IOC)" , PVAS_AUTO_BEACON_ADDR_LIST , EPICS_PVAS_AUTO_BEACON_ADDR_LIST , env  }
+    { "$(IOC)" , PVAS_BEACON_ADDR_LIST ,      EPICS_PVAS_BEACON_ADDR_LIST      , env  }
+    { "$(IOC)" , PVAS_BEACON_PERIOD ,         EPICS_PVAS_BEACON_PERIOD         , env  }
+    { "$(IOC)" , PVAS_BROADCAST_PORT ,        EPICS_PVAS_BROADCAST_PORT        , env  }
+    { "$(IOC)" , PVAS_SERVER_PORT ,           EPICS_PVAS_SERVER_PORT           , env  }
 }
 file iocCluster.template
 {

--- a/iocAdmin/Db/iocAdminSoft.substitutions
+++ b/iocAdmin/Db/iocAdminSoft.substitutions
@@ -16,6 +16,12 @@ file iocGeneralTime.template
 pattern { IOCNAME }
 	{ "$(IOC)"  }
 }
+file iocAdminScanMon.db
+{
+	pattern
+	{	IOCNAME	 }
+	{	"$(IOC)" }
+}
 file iocEnvVar.template
 {
 pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}

--- a/iocAdmin/Db/iocAdminSoft.substitutions
+++ b/iocAdmin/Db/iocAdminSoft.substitutions
@@ -22,7 +22,7 @@ file iocAdminScanMon.db
 	{	IOCNAME	 }
 	{	"$(IOC)" }
 }
-file iocEnvVar.template
+file epicsEnvVars.db
 {
 pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ "$(IOC)" , CA_ADDR_LIST , EPICS_CA_ADDR_LIST              , epics  } 

--- a/iocAdmin/Db/iocAdminSoft.substitutions
+++ b/iocAdmin/Db/iocAdminSoft.substitutions
@@ -33,6 +33,15 @@ pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ "$(IOC)" , CA_MAX_ARRAY , EPICS_CA_MAX_ARRAY_BYTES        , epics  }
 	{ "$(IOC)" , CA_SRCH_TIME , EPICS_CA_MAX_SEARCH_PERIOD      , epics  }
 	{ "$(IOC)" , CA_BEAC_TIME , EPICS_CA_BEACON_PERIOD          , epics  }
+
+	{ "$(IOC)" , CAS_SRVR_PORT        , EPICS_CAS_SERVER_PORT          , epics  }
+	{ "$(IOC)" , CAS_AUTO_ADDR        , EPICS_CAS_AUTO_BEACON_ADDR_LIST, epics  }
+	{ "$(IOC)" , CAS_ADDR_LIST        , EPICS_CAS_BEACON_ADDR_LIST     , epics  } 
+	{ "$(IOC)" , CAS_BEACON_PERIOD    , EPICS_CAS_BEACON_PERIOD        , epics  }
+	{ "$(IOC)" , CAS_BEACON_PORT      , EPICS_CAS_BEACON_PORT          , epics  }
+	{ "$(IOC)" , CAS_ADDR_INTF_LIST   , EPICS_CAS_INTF_ADDR_LIST       , epics  } 
+	{ "$(IOC)" , CAS_ADDR_IGNORE_LIST , EPICS_CAS_IGNORE_ADDR_LIST     , epics  } 
+
 	{ "$(IOC)" , TS_NTP_INET  , EPICS_TS_NTP_INET               , epics  }
 	{ "$(IOC)" , IOC_LOG_PORT , EPICS_IOC_LOG_PORT              , epics  }
 	{ "$(IOC)" , IOC_LOG_INET , EPICS_IOC_LOG_INET              , epics  }

--- a/iocAdmin/Db/iocAdminSoft.substitutions
+++ b/iocAdmin/Db/iocAdminSoft.substitutions
@@ -30,4 +30,18 @@ pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ "$(IOC)" , TS_NTP_INET  , EPICS_TS_NTP_INET               , epics  }
 	{ "$(IOC)" , IOC_LOG_PORT , EPICS_IOC_LOG_PORT              , epics  }
 	{ "$(IOC)" , IOC_LOG_INET , EPICS_IOC_LOG_INET              , epics  }
+
+    { "$(IOC)" , PVA_ADDR_LIST ,      EPICS_PVA_ADDR_LIST       , epics  }
+    { "$(IOC)" , PVA_AUTO_ADDR ,      EPICS_PVA_AUTO_ADDR       , epics  }
+    { "$(IOC)" , PVA_DEBUG ,          EPICS_PVA_DEBUG           , epics  }
+    { "$(IOC)" , PVA_CONN_TMO ,       EPICS_PVA_CONN_TMO        , epics  }
+    { "$(IOC)" , PVA_BEACON_PERIOD ,  EPICS_PVA_BEACON_PERIOD   , epics  }
+    { "$(IOC)" , PVA_BROADCAST_PORT , EPICS_PVA_BROADCAST_PORT  , epics  }
+    { "$(IOC)" , PVA_SERVER_PORT ,    EPICS_PVA_SERVER_PORT     , epics  }
+
+    { "$(IOC)" , PVAS_BEACON_ADDR_LIST ,      EPICS_PVAS_BEACON_ADDR_LIST      , epics  }
+    { "$(IOC)" , PVAS_AUTO_BEACON_ADDR_LIST , EPICS_PVAS_AUTO_BEACON_ADDR_LIST , epics  }
+    { "$(IOC)" , PVAS_SERVER_PORT ,           EPICS_PVAS_SERVER_PORT           , epics  }
+    { "$(IOC)" , PVAS_BEACON_PERIOD ,         EPICS_PVAS_BEACON_PERIOD         , epics  }
+    { "$(IOC)" , PVAS_BROADCAST_PORT ,        EPICS_PVAS_BROADCAST_PORT        , epics  }
 }

--- a/iocAdmin/Db/iocAdminVxWorks.substitutions
+++ b/iocAdmin/Db/iocAdminVxWorks.substitutions
@@ -16,6 +16,12 @@ file iocGeneralTime.template
 pattern { IOCNAME }
 	{ "$(IOC)"  }
 }
+file iocAdminScanMon.db
+{
+	pattern
+	{	IOCNAME	 }
+	{	"$(IOC)" }
+}
 file iocRTOS.template
 {
 pattern { IOCNAME , SYS_MBUF_FLNK     }

--- a/iocAdmin/Db/iocAdminVxWorks.substitutions
+++ b/iocAdmin/Db/iocAdminVxWorks.substitutions
@@ -43,11 +43,32 @@ pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ "$(IOC)" , CA_MAX_ARRAY , EPICS_CA_MAX_ARRAY_BYTES        , epics  }
 	{ "$(IOC)" , CA_SRCH_TIME , EPICS_CA_MAX_SEARCH_PERIOD      , epics  }
 	{ "$(IOC)" , CA_BEAC_TIME , EPICS_CA_BEACON_PERIOD          , epics  }
-	{ "$(IOC)" , TIMEZONE     , EPICS_TIMEZONE                  , epics  }
-	{ "$(IOC)" , TZ           , EPICS_TZ                        , epics  }
+
+	{ "$(IOC)" , CAS_SRVR_PORT        , EPICS_CAS_SERVER_PORT          , epics  }
+	{ "$(IOC)" , CAS_AUTO_ADDR        , EPICS_CAS_AUTO_BEACON_ADDR_LIST, epics  }
+	{ "$(IOC)" , CAS_ADDR_LIST        , EPICS_CAS_BEACON_ADDR_LIST     , epics  } 
+	{ "$(IOC)" , CAS_BEACON_PERIOD    , EPICS_CAS_BEACON_PERIOD        , epics  }
+	{ "$(IOC)" , CAS_BEACON_PORT      , EPICS_CAS_BEACON_PORT          , epics  }
+	{ "$(IOC)" , CAS_ADDR_INTF_LIST   , EPICS_CAS_INTF_ADDR_LIST       , epics  } 
+	{ "$(IOC)" , CAS_ADDR_IGNORE_LIST , EPICS_CAS_IGNORE_ADDR_LIST     , epics  } 
+
 	{ "$(IOC)" , TS_NTP_INET  , EPICS_TS_NTP_INET               , epics  }
 	{ "$(IOC)" , IOC_LOG_PORT , EPICS_IOC_LOG_PORT              , epics  }
 	{ "$(IOC)" , IOC_LOG_INET , EPICS_IOC_LOG_INET              , epics  }
+
+    { "$(IOC)" , PVA_ADDR_LIST ,      EPICS_PVA_ADDR_LIST       , epics  }
+    { "$(IOC)" , PVA_AUTO_ADDR ,      EPICS_PVA_AUTO_ADDR_LIST  , epics  }
+    { "$(IOC)" , PVA_BEACON_PERIOD ,  EPICS_PVA_BEACON_PERIOD   , epics  }
+    { "$(IOC)" , PVA_BROADCAST_PORT , EPICS_PVA_BROADCAST_PORT  , epics  }
+    { "$(IOC)" , PVA_CONN_TMO ,       EPICS_PVA_CONN_TMO        , epics  }
+    { "$(IOC)" , PVA_DEBUG ,          EPICS_PVA_DEBUG           , epics  }
+    { "$(IOC)" , PVA_SERVER_PORT ,    EPICS_PVA_SERVER_PORT     , epics  }
+
+    { "$(IOC)" , PVAS_AUTO_BEACON_ADDR_LIST , EPICS_PVAS_AUTO_BEACON_ADDR_LIST , env  }
+    { "$(IOC)" , PVAS_BEACON_ADDR_LIST ,      EPICS_PVAS_BEACON_ADDR_LIST      , env  }
+    { "$(IOC)" , PVAS_BEACON_PERIOD ,         EPICS_PVAS_BEACON_PERIOD         , env  }
+    { "$(IOC)" , PVAS_BROADCAST_PORT ,        EPICS_PVAS_BROADCAST_PORT        , env  }
+    { "$(IOC)" , PVAS_SERVER_PORT ,           EPICS_PVAS_SERVER_PORT           , env  }
 }
 file iocCluster.template
 {

--- a/iocAdmin/Db/iocAdminVxWorks.substitutions
+++ b/iocAdmin/Db/iocAdminVxWorks.substitutions
@@ -32,7 +32,7 @@ file iocVxWorksOnly.template
 pattern { IOCNAME , DAT_MBUF_FLNK     }
 	{ "$(IOC)"  , "$(IOC):CLUST_0_0_0"}
 }
-file iocEnvVar.template
+file epicsEnvVars.db
 {
 pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ "$(IOC)" , CA_ADDR_LIST , EPICS_CA_ADDR_LIST              , epics  } 


### PR DESCRIPTION
Adds EPICS env variables for PVA and CAS to iocAdmin substitution files.

Also simplifies build by including iocAdminScanMon.db in above substitution files and breaking out env variables into a single file included by each iocAdmin*.substitutions variant.
EPICS 7 env variables are conditionally mapped to env or epics depending on base version.