### PR TITLE
Fix for issue #20

### DIFF
--- a/devIocStats/os/WIN32/osdCpuUtilization.c
+++ b/devIocStats/os/WIN32/osdCpuUtilization.c
@@ -23,6 +23,7 @@
 
 #if defined(__MINGW32__) || defined(__MINGW64__)
 #define WINVER 0x0501
+#define _WIN32_WINNT 0x0601
 #endif
 
 #include <windows.h>

--- a/devIocStats/os/WIN32/osdMemUsage.c
+++ b/devIocStats/os/WIN32/osdMemUsage.c
@@ -25,6 +25,7 @@
 
 #if defined(__MINGW32__) || defined(__MINGW64__)
 #define WINVER 0x0501
+#define _WIN32_WINNT 0x0601
 #endif
 
 #include <windows.h>


### PR DESCRIPTION
As indicated by the MinGW group the bug is actually the missing definition of WIN32 version, not with the usage of the function itself since it is only available in Windows 7+. Since most computers should be running Windows 7 by now it probably can be assumed to be the case that this should be available. Epics Base has already implemented the fix in their repo to link the psapi library so the only leftover change to implement is this.