### PR TITLE
Fix a few other incorrectly documented iocstats input types

### DIFF
--- a/README_devIocStats
+++ b/README_devIocStats
@@ -75,7 +75,7 @@ Analog In (ai) Records (DTYP = "IOC stats"), INP = @one of the following:
         no_of_cpus            - number of CPU cores on the system
         ioc_cpuload           - estimated percent CPU utilization by this IOC
         fd                    - number of file descriptors currently in use
-        max_fd                - max number of file descriptors
+        maxfd                 - max number of file descriptors
     Note - free_bytes, total_bytes, sys_cpuload, no_of_cpus can be instantiated once per system instead
     of per IOC if desired (ie, when multiple IOCs run on the same system).
     The following are implemented for RTEMS and vxWorks IOCs only and set to 0 for other types of IOCs:
@@ -104,13 +104,13 @@ Analog In (ai) Records for Cluster Statistics (RTEMS and vxWorks IOCs only)
 
 Analog Out (ao) Records (DTYP = "IOC stats"), OUT = @one of the following:
 ==========================================================================
-        memoryScanRate        - max period (sec) at which new memory stats 
+        memory_scan_rate      - max period (sec) at which new memory stats 
             can be read, default = 10 sec
-        fdScanRate            - max period (sec) at which file descriptors 
+        fd_scan_rate          - max period (sec) at which file descriptors 
             can be counted, default = 20 sec
         cpu_scan_rate         - max period (sec) at which cpu load 
             can be calculated, default = 10 sec 
-        caConnScanRate        - max period (sec) at which CA connections 
+        ca_scan_rate          - max period (sec) at which CA connections 
             can be counted, default = 15 sec
 
 Subroutine (sub) Records, SNAM = one of the following:

--- a/devIocStats/devIocStatsAnalog.c
+++ b/devIocStats/devIocStatsAnalog.c
@@ -68,7 +68,7 @@
               ( cpu		 - same as ioc_cpuload [for compatibility] )
                 suspended_tasks	 - number of suspended tasks
 		fd		 - number of file descriptors currently in use
-		max_fd		 - max number of file descriptors
+		maxfd		 - max number of file descriptors
 		ca_clients	 - number of current CA clients
 		ca_connections	 - number of current CA connections
                 min_data_mbuf    - minimum percent free data   MBUFs
@@ -92,10 +92,10 @@
 
 
 	ao:
-		memoryScanRate	 - max rate at which new memory stats can be read
-		fdScanRate	 - max rate at which file descriptors can be counted
+		memory_scan_rate	 - max rate at which new memory stats can be read
+		fd_scan_rate	 - max rate at which file descriptors can be counted
 		cpu_scan_rate	 - max rate at which cpu load can be calculated
-		caConnScanRate	 - max rate at which CA connections can be calculated
+		ca_scan_rate	 - max rate at which CA connections can be calculated
 
 	* scan rates are all in seconds
 


### PR DESCRIPTION
Followup to #47 , there were several other types where the documentation did not match the actual types.