### PR TITLE
Fix issue where (potentially undefined) site-specific vars were being fetched

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -4,6 +4,8 @@ Release Notes for iocStats
 
 * Changes by Simon Rose:
   - Added GitHub workflow using EPICS CI scripts
+  - Add parsing of CONFIG_SITE_ENV from EPICS base to fetch additional EPICS
+    environment variables
 * Changes by Martin Konrad:
   - Fix EPICS_TZ warning for VxWorks and RTEMS
 

--- a/iocAdmin/Db/Makefile
+++ b/iocAdmin/Db/Makefile
@@ -11,6 +11,7 @@ include $(TOP)/configure/CONFIG
 # Create and install (or just install)
 # databases, templates, substitutions like this
 #
+DB += siteEnvVars.db
 DB += epicsEnvVars.db
 DB += iocAdminScanMon.db
 DB += ioc.db
@@ -27,10 +28,6 @@ DB += iocAdminVxWorks.db
 DB += iocAdminSoft.db
 DB += iocAdminRTEMS.db
 
-ifdef BASE_7_0
-USR_DBFLAGS += -M V4_ENVTYPE=epics
-endif
-
 #
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add
@@ -41,8 +38,17 @@ include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
 
-$(COMMON_DIR)/iocAdminRTEMS.db:   $(COMMON_DIR)/iocAdminScanMon.db $(COMMON_DIR)/epicsEnvVars.db
+$(COMMON_DIR)/iocAdminRTEMS.db:   $(COMMON_DIR)/iocAdminScanMon.db $(COMMON_DIR)/epicsEnvVars.db $(COMMON_DIR)/siteEnvVars.db
 
-$(COMMON_DIR)/iocAdminSoft.db:    $(COMMON_DIR)/iocAdminScanMon.db $(COMMON_DIR)/epicsEnvVars.db
+$(COMMON_DIR)/iocAdminSoft.db:    $(COMMON_DIR)/iocAdminScanMon.db $(COMMON_DIR)/epicsEnvVars.db $(COMMON_DIR)/siteEnvVars.db
 
-$(COMMON_DIR)/iocAdminVxWorks.db: $(COMMON_DIR)/iocAdminScanMon.db $(COMMON_DIR)/epicsEnvVars.db
+$(COMMON_DIR)/iocAdminVxWorks.db: $(COMMON_DIR)/iocAdminScanMon.db $(COMMON_DIR)/epicsEnvVars.db $(COMMON_DIR)/siteEnvVars.db
+
+$(COMMON_DIR)/siteEnvVars.substitutions: $(EPICS_BASE)/configure/CONFIG_SITE_ENV
+	@echo Expanding siteEnvVars.substitutions from CONFIG_SITE_ENV....
+	@echo "file iocEnvVar.template" > $@
+	@echo "{" >> $@
+	@echo "pattern" >> $@
+	@echo "{ ENVNAME, ENVVAR, ENVTYPE }" >> $@
+	@sed -n 's/^EPICS_\([A-Z_]*\).*/{\1, EPICS_\1, epics}/p' $< >> $@
+	@echo "}" >> $@

--- a/iocAdmin/Db/epicsEnvVars.substitutions
+++ b/iocAdmin/Db/epicsEnvVars.substitutions
@@ -26,23 +26,4 @@ file iocEnvVar.template
     { CAS_BEACON_PORT            , EPICS_CAS_BEACON_PORT           , epics  }
     { CAS_ADDR_INTF_LIST         , EPICS_CAS_INTF_ADDR_LIST        , epics  } 
     { CAS_ADDR_IGNORE_LIST       , EPICS_CAS_IGNORE_ADDR_LIST      , epics  } 
-
-    { TIMEZONE                   , EPICS_TIMEZONE                  , epics  }
-    { TS_NTP_INET                , EPICS_TS_NTP_INET               , epics  }
-    { IOC_LOG_PORT               , EPICS_IOC_LOG_PORT              , epics  }
-    { IOC_LOG_INET               , EPICS_IOC_LOG_INET              , epics  }
-
-    { PVA_ADDR_LIST              , EPICS_PVA_ADDR_LIST       , $(V4_ENVTYPE=env)  }
-    { PVA_AUTO_ADDR              , EPICS_PVA_AUTO_ADDR_LIST  , $(V4_ENVTYPE=env)  }
-    { PVA_BEACON_PERIOD          , EPICS_PVA_BEACON_PERIOD   , $(V4_ENVTYPE=env)  }
-    { PVA_BROADCAST_PORT         , EPICS_PVA_BROADCAST_PORT  , $(V4_ENVTYPE=env)  }
-    { PVA_CONN_TMO               , EPICS_PVA_CONN_TMO        , $(V4_ENVTYPE=env)  }
-    { PVA_DEBUG                  , EPICS_PVA_DEBUG           , $(V4_ENVTYPE=env)  }
-    { PVA_SERVER_PORT            , EPICS_PVA_SERVER_PORT     , $(V4_ENVTYPE=env)  }
-
-    { PVAS_AUTO_BEACON_ADDR_LIST, EPICS_PVAS_AUTO_BEACON_ADDR_LIST , $(V4_ENVTYPE=env)  }
-    { PVAS_BEACON_ADDR_LIST     , EPICS_PVAS_BEACON_ADDR_LIST      , $(V4_ENVTYPE=env)  }
-    { PVAS_BEACON_PERIOD        , EPICS_PVAS_BEACON_PERIOD         , $(V4_ENVTYPE=env)  }
-    { PVAS_BROADCAST_PORT       , EPICS_PVAS_BROADCAST_PORT        , $(V4_ENVTYPE=env)  }
-    { PVAS_SERVER_PORT          , EPICS_PVAS_SERVER_PORT           , $(V4_ENVTYPE=env)  }
 }

--- a/iocAdmin/Db/iocAdminSoft.substitutions
+++ b/iocAdmin/Db/iocAdminSoft.substitutions
@@ -28,3 +28,8 @@ pattern { IOCNAME, }
 	{ "$(IOC)" } 
 }
 
+file siteEnvVars.db
+{
+pattern { IOCNAME, }
+	{ "$(IOC)" } 
+}


### PR DESCRIPTION
In commit https://github.com/epics-modules/iocStats/commit/e320eb5888eaecda6c0977c7bca7739e40244752, several PVA-related env vars were added to the default iocAdmin database files. Unfortunately these are not defined by default in EPICS base and as such warnings were generated at IOC startup in that case.

The variables are defined in CONFIG_SITE_ENV and CONFIG_ENV; as such we just automatically parse those files for site-specific variables and add them accordingly.