### PR TITLE
Add support to monitor CPU temperature

### DIFF
--- a/devIocStats/Makefile
+++ b/devIocStats/Makefile
@@ -44,6 +44,7 @@ SRCS += osdBootInfo.c
 SRCS += osdSystemInfo.c
 SRCS += osdHostInfo.c
 SRCS += osdPIDInfo.c
+SRCS += osdCpuTemp.c
 
 OBJS_vxWorks += osdCpuUsageTest.o
 

--- a/devIocStats/devIocStats.h
+++ b/devIocStats/devIocStats.h
@@ -132,4 +132,7 @@ extern int devIocStatsGetHostname(char **pval);
 extern int devIocStatsGetPID(double *proc_id);
 extern int devIocStatsGetPPID(double *proc_id);
 
+/* CPU Temperature */
+extern int devIocStatsGetCpuTemp(int *pval);
+
 #endif /* devIocStats_H */

--- a/devIocStats/devIocStatsAnalog.c
+++ b/devIocStats/devIocStatsAnalog.c
@@ -200,6 +200,7 @@ static void statsWSAllocBytes(double *);
 static void statsWSTotalBytes(double *);
 static void statsCpuUsage(double *);
 static void statsCpuUtilization(double *);
+static void statsCpuTemperature(double *);
 static void statsNoOfCpus(double *);
 static void statsSuspendedTasks(double *);
 static void statsFdUsage(double *);
@@ -281,6 +282,7 @@ static validGetParms statsGetParms[] = {
     {"cbHighQueueHiWtrMrk", statsCbHighQHiWtrMrk, QUEUE_TYPE},
     {"cbHighQueueUsed", statsCbHighQUsed, QUEUE_TYPE},
     {"cbHighQueueOverruns", statsCbHighQOverruns, QUEUE_TYPE},
+    {"cpu_temperature", statsCpuTemperature, LOAD_TYPE},
     {NULL, NULL, 0}};
 
 aStats devAiStats = {6,       NULL, ai_init, ai_init_record, ai_ioint_info,
@@ -303,6 +305,7 @@ static scanInfo scan[TOTAL_TYPES] = {{0}};
 static fdInfo fdusage = {0, 0};
 static loadInfo loadinfo = {1, 0., 0.};
 static int susptasknumber = 0;
+static int cputemperature = 0;
 static int recordnumber = 0;
 static clustInfo clustinfo[2] = {{{0}}, {{0}}};
 static int mbufnumber[2] = {0, 0};
@@ -374,12 +377,15 @@ static void scan_time(int type) {
   case LOAD_TYPE: {
     loadInfo loadinfo_local = {1, 0., 0.};
     int susptasknumber_local = 0;
+    int cputemperature_local = 0;
     devIocStatsGetCpuUsage(&loadinfo_local);
     devIocStatsGetCpuUtilization(&loadinfo_local);
     devIocStatsGetSuspTasks(&susptasknumber_local);
+    devIocStatsGetCpuTemp(&cputemperature_local);
     epicsMutexLock(scan_mutex);
     loadinfo = loadinfo_local;
     susptasknumber = susptasknumber_local;
+    cputemperature = cputemperature_local;
     epicsMutexUnlock(scan_mutex);
     break;
   }
@@ -683,6 +689,7 @@ static void statsWSTotalBytes(double *val) {
 }
 static void statsCpuUsage(double *val) { *val = loadinfo.cpuLoad; }
 static void statsCpuUtilization(double *val) { *val = loadinfo.iocLoad; }
+static void statsCpuTemperature(double *val) { *val = (double)cputemperature/1000.; }
 static void statsNoOfCpus(double *val) { *val = (double)loadinfo.noOfCpus; }
 static void statsSuspendedTasks(double *val) { *val = (double)susptasknumber; }
 static void statsFdUsage(double *val) { *val = (double)fdusage.used; }

--- a/devIocStats/os/Linux/osdCpuTemp.c
+++ b/devIocStats/os/Linux/osdCpuTemp.c
@@ -1,0 +1,40 @@
+/*************************************************************************\
+* Copyright (c) 2009 Helmholtz-Zentrum Berlin fuer Materialien und Energie.
+* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2002 The Regents of the University of California, as
+*     Operator of Los Alamos National Laboratory.
+* EPICS BASE Versions 3.13.7
+* and higher are distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/* osdCpuTemp.c - Temperature of the CPU: default implementation = do nothing */
+
+/*
+ *  Author: Florian Feldbauer (RUB)
+ *
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <devIocStats.h>
+
+int devIocStatsGetCpuTemp(int *pval) {
+  FILE *pFile = fopen ( "/sys/class/thermal/thermal_zone0/temp", "r" );
+  if( !pFile ) {
+    fprintf( stderr, "\033[31;1m: Could not open file '/sys/class/thermal/thermal_zone0/temp': %s\033[0m\n",
+             strerror( errno ) );
+    return -1;
+  }
+
+  unsigned num = fscanf( pFile, "%d", pval );
+  if ( 1 != num ) {
+    fprintf( stderr, "\033[31;1mCould not parse value\033[0m\n" );
+  }
+  fclose( pFile );
+  return 0;
+}

--- a/devIocStats/os/default/osdCpuTemp.c
+++ b/devIocStats/os/default/osdCpuTemp.c
@@ -1,0 +1,21 @@
+/*************************************************************************\
+* Copyright (c) 2009 Helmholtz-Zentrum Berlin fuer Materialien und Energie.
+* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2002 The Regents of the University of California, as
+*     Operator of Los Alamos National Laboratory.
+* EPICS BASE Versions 3.13.7
+* and higher are distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/* osdCpuTemp.c - Temperature of the CPU: default implementation = do nothing */
+
+/*
+ *  Author: Florian Feldbauer (RUB)
+ *
+ */
+
+#include <devIocStats.h>
+
+int devIocStatsGetCpuTemp (int *pval) { return -1; }


### PR DESCRIPTION
Added support to monitor the CPU temperature on Linux. New function uses the LOAD_TYPE scan rate like all the other CPU related informations.