### PR TITLE
Update to RTEMS 6 with Libbsd and Legacy net support

### DIFF
--- a/devIocStats/os/RTEMS/osdCpuUtilization.c
+++ b/devIocStats/os/RTEMS/osdCpuUtilization.c
@@ -27,7 +27,6 @@ int devIocStatsInitCpuUtilization(loadInfo *pval) {
   return 0;
 }
 
-/* FIXME: This relies on the device support calling it after CpuUsage */
 int devIocStatsGetCpuUtilization(loadInfo *pval) {
   pval->iocLoad = pval->cpuLoad;
   return 0;

--- a/devIocStats/os/RTEMS/osdFdUsage.c
+++ b/devIocStats/os/RTEMS/osdFdUsage.c
@@ -38,9 +38,16 @@
 
 #include <devIocStats.h>
 
+#if __RTEMS_MAJOR__ >= 6
+#include <rtems/libio_.h>
+#endif /* _RTEMS_MAJOR__ >= 6 */
+
 int devIocStatsInitFDUsage(void) { return 0; }
 
 int devIocStatsGetFDUsage(fdInfo *pval) {
+#if __RTEMS_MAJOR__ >= 6
+  pval->used = rtems_libio_count_open_iops();
+#else
   int i, tot;
 
   for (tot = 0, i = 0; i < rtems_libio_number_iops; i++) {
@@ -48,6 +55,7 @@ int devIocStatsGetFDUsage(fdInfo *pval) {
       tot++;
   }
   pval->used = tot;
+#endif /* _RTEMS_MAJOR__ >= 6 */
   pval->max = rtems_libio_number_iops;
   return 0;
 }

--- a/devIocStats/os/RTEMS/osdSuspTasks.c
+++ b/devIocStats/os/RTEMS/osdSuspTasks.c
@@ -43,6 +43,7 @@
 int devIocStatsInitSuspTasks(void) { return 0; }
 
 int devIocStatsGetSuspTasks(int *pval) {
+#if __RTEMS_MAJOR__ < 6
   Objects_Control *o;
   Objects_Id id = OBJECTS_ID_INITIAL_INDEX;
   Objects_Id nid;
@@ -59,4 +60,7 @@ int devIocStatsGetSuspTasks(int *pval) {
   }
   *pval = n;
   return 0;
+#else  /* __RTEMS_MAJOR__ < 6 */
+  return -1;
+#endif /* __RTEMS_MAJOR__ < 6 */
 }

--- a/devIocStats/os/RTEMS/osdWorkspaceUsage.c
+++ b/devIocStats/os/RTEMS/osdWorkspaceUsage.c
@@ -31,6 +31,10 @@ int devIocStatsInitWorkspaceUsage(void) { return 0; }
 
 int devIocStatsGetWorkspaceUsage(memInfo *pval) {
   Heap_Information_block info;
+#if __RTEMS_MAJOR__ >= 6
+  malloc_info(&info);
+  pval->numBytesTotal = info.Stats.size;
+#else /* __RTEMS_MAJOR__ >= 6 */
 #ifdef RTEMS_PROTECTED_HEAP
   _Protected_heap_Get_information(&_Workspace_Area, &info);
 #else  /* RTEMS_PROTECTED_HEAP */
@@ -45,6 +49,7 @@ int devIocStatsGetWorkspaceUsage(memInfo *pval) {
 #else
   pval->numBytesTotal = _Configuration_Table->work_space_size;
 #endif
+#endif /* _RTEMS_MAJOR__ >= 6 */
   pval->numBytesFree = info.Free.total;
   pval->numBytesAlloc = info.Used.total;
   return 0;


### PR DESCRIPTION
This pull request adds support for RTEMS 6 for the legacy network and libbsd.

It needs a current build of RTEMS 6 and tools.