### PR TITLE
Use perl instead of sed

### DIFF
--- a/iocAdmin/Db/Makefile
+++ b/iocAdmin/Db/Makefile
@@ -46,9 +46,9 @@ $(COMMON_DIR)/iocAdminVxWorks.db: $(COMMON_DIR)/iocAdminScanMon.db $(COMMON_DIR)
 
 $(COMMON_DIR)/siteEnvVars.substitutions: $(EPICS_BASE)/configure/CONFIG_SITE_ENV
 	@echo Expanding siteEnvVars.substitutions from CONFIG_SITE_ENV....
-	@echo "file iocEnvVar.template" > $@
-	@echo "{" >> $@
-	@echo "pattern" >> $@
-	@echo "{ ENVNAME, ENVVAR, ENVTYPE }" >> $@
-	@sed -n 's/^EPICS_\([A-Z_]*\).*/{\1, EPICS_\1, epics}/p' $< >> $@
-	@echo "}" >> $@
+	@echo file iocEnvVar.template> $@
+	@echo {>> $@
+	@echo pattern>> $@
+	@echo { ENVNAME, ENVVAR, ENVTYPE }>> $@
+	@perl -n -e "$$m = s/^EPICS_([A-Z_]*).*/{$${1}, EPICS_$${1}, epics}/; print $$_ if $$m;" < $< >> $@
+	@echo }>> $@


### PR DESCRIPTION
Windows does not have `sed` so change to use `perl` that is already needed for building EPICS

See epics-modules/iocStats#62