### PR TITLE
Fix Makefile echo syntax for siteEnvVars.substitutions for portablity on windows

### DIFF
--- a/iocAdmin/Db/Makefile
+++ b/iocAdmin/Db/Makefile
@@ -46,9 +46,9 @@ $(COMMON_DIR)/iocAdminVxWorks.db: $(COMMON_DIR)/iocAdminScanMon.db $(COMMON_DIR)
 
 $(COMMON_DIR)/siteEnvVars.substitutions: $(EPICS_BASE)/configure/CONFIG_SITE_ENV
 	@echo Expanding siteEnvVars.substitutions from CONFIG_SITE_ENV....
-	@echo "file iocEnvVar.template" > $@
-	@echo "{" >> $@
-	@echo "pattern" >> $@
-	@echo "{ ENVNAME, ENVVAR, ENVTYPE }" >> $@
-	@sed -n 's/^EPICS_\([A-Z_]*\).*/{\1, EPICS_\1, epics}/p' $< >> $@
-	@echo "}" >> $@
+	@echo file iocEnvVar.template > $@
+	@echo { >> $@
+	@echo pattern >> $@
+	@echo { ENVNAME, ENVVAR, ENVTYPE } >> $@
+	@sed -n "s/^EPICS_\([A-Z_]*\).*/{\1, EPICS_\1, epics}/p" $< >> $@
+	@echo } >> $@


### PR DESCRIPTION
See https://github.com/epics-modules/iocStats/issues/71

On windows, [this makefile](https://github.com/epics-modules/iocStats/blob/7dc2557187a75c18ab16bb296fa934b35400df0a/iocAdmin/Db/Makefile#L50) generates siteEnvVars.substitutions incorrectly, resulting in:
```
"file iocEnvVar.template" 
"{" 
"pattern" 
"{ ENVNAME, ENVVAR, ENVTYPE }" 
```
The intended output should be:
```
file iocEnvVar.template {
    pattern { ENVNAME, ENVVAR, ENVTYPE }
}
```
This appears to be from subtleties of echo on windows vs linux.

This PR modifies the echo usage to work on windows. It should also work on linux.

TODO:
- [ ] Test that changes don't affect usage on linux.