### PR TITLE
Prevent duplicate PVs being auto-generated

### DIFF
--- a/iocAdmin/Db/Makefile
+++ b/iocAdmin/Db/Makefile
@@ -49,5 +49,5 @@ $(COMMON_DIR)/siteEnvVars.substitutions: $(EPICS_BASE)/configure/CONFIG_SITE_ENV
 	@echo { >> $@
 	@echo pattern >> $@
 	@echo { ENVNAME, ENVVAR, ENVTYPE } >> $@
-	@sed -n "s/^EPICS_\([A-Z_]*\).*/{\1, EPICS_\1, epics}/p" $^ >> $@
+	@sed -n "s/^EPICS_\([A-Z_]*\).*/{\1, EPICS_\1, epics}/p" $^ | sort -u >> $@
 	@echo } >> $@


### PR DESCRIPTION
Hi Simon,
This commit was missed in #69. This prevent duplicates being generated if variables are redefined in CONFIG_SITE_ENV (or defined more than once in any combination of CONFIG_ENV and CONFIG_SITE_ENV). I don't have a way to test it on Windows, but I believe cygwin ships `sort` as well.
