### PR TITLE
Update reference screens to use new record names

### DIFF
--- a/iocAdmin/srcDisplay/ioc_stats_epics_env.edl
+++ b/iocAdmin/srcDisplay/ioc_stats_epics_env.edl
@@ -70,7 +70,7 @@ x 280
 y 80
 w 150
 h 20
-controlPv "$(ioc):CA_RPTR_PORT"
+controlPv "$(ioc):CA_REPEATER_PORT"
 displayMode "decimal"
 fgColor index 16
 fgAlarm
@@ -112,7 +112,7 @@ x 280
 y 55
 w 150
 h 20
-controlPv "$(ioc):CA_SRVR_PORT"
+controlPv "$(ioc):CA_SERVER_PORT"
 displayMode "decimal"
 fgColor index 16
 fgAlarm
@@ -154,7 +154,7 @@ x 280
 y 180
 w 150
 h 20
-controlPv "$(ioc):CA_CONN_TIME"
+controlPv "$(ioc):CA_CONN_TMO"
 displayMode "decimal"
 fgColor index 16
 fgAlarm
@@ -238,7 +238,7 @@ x 280
 y 130
 w 150
 h 20
-controlPv "$(ioc):CA_AUTO_ADDR"
+controlPv "$(ioc):CA_AUTO_ADDR_LIST"
 displayMode "decimal"
 fgColor index 16
 fgAlarm
@@ -280,7 +280,7 @@ x 280
 y 205
 w 150
 h 20
-controlPv "$(ioc):CA_SRCH_TIME"
+controlPv "$(ioc):CA_MAX_SEARCH_PERIOD"
 displayMode "decimal"
 fgColor index 16
 fgAlarm
@@ -322,7 +322,7 @@ x 280
 y 230
 w 150
 h 20
-controlPv "$(ioc):CA_BEAC_TIME"
+controlPv "$(ioc):CA_BEACON_PERIOD"
 displayMode "decimal"
 fgColor index 16
 fgAlarm
@@ -364,7 +364,7 @@ x 280
 y 155
 w 150
 h 20
-controlPv "$(ioc):CA_MAX_ARRAY"
+controlPv "$(ioc):CA_MAX_ARRAY_BYTES"
 displayMode "decimal"
 fgColor index 16
 fgAlarm

--- a/iocAdmin/srcDisplay/ioc_stats_epics_env.edl
+++ b/iocAdmin/srcDisplay/ioc_stats_epics_env.edl
@@ -391,7 +391,7 @@ fgColor index 14
 bgColor index 3
 useDisplayBg
 value {
-  "EPICS_TIMEZONE"
+  "EPICS_TZ"
 }
 autoSize
 endObjectProperties
@@ -406,7 +406,7 @@ x 190
 y 255
 w 310
 h 20
-controlPv "$(ioc):TIMEZONE"
+controlPv "$(ioc):TZ"
 displayMode "decimal"
 fgColor index 16
 fgAlarm

--- a/op/adl/ioc_stats_epics_env.adl
+++ b/op/adl/ioc_stats_epics_env.adl
@@ -216,7 +216,7 @@ text {
 	"basic attribute" {
 		clr=14
 	}
-	textix="EPICS_TIMEZONE"
+	textix="EPICS_TZ"
 }
 text {
 	object {
@@ -390,7 +390,7 @@ text {
 		height=15
 	}
 	monitor {
-		chan="$(ioc):TIMEZONE"
+		chan="$(ioc):TZ"
 		clr=14
 		bclr=4
 	}

--- a/op/adl/ioc_stats_epics_env.adl
+++ b/op/adl/ioc_stats_epics_env.adl
@@ -262,7 +262,7 @@ text {
 		height=15
 	}
 	monitor {
-		chan="$(ioc):CA_SRVR_PORT"
+		chan="$(ioc):CA_SERVER_PORT"
 		clr=14
 		bclr=4
 	}
@@ -278,7 +278,7 @@ text {
 		height=15
 	}
 	monitor {
-		chan="$(ioc):CA_RPTR_PORT"
+		chan="$(ioc):CA_REPEATER_PORT"
 		clr=14
 		bclr=4
 	}
@@ -310,7 +310,7 @@ text {
 		height=15
 	}
 	monitor {
-		chan="$(ioc):CA_AUTO_ADDR"
+		chan="$(ioc):CA_AUTO_ADDR_LIST"
 		clr=14
 		bclr=4
 	}
@@ -326,7 +326,7 @@ text {
 		height=15
 	}
 	monitor {
-		chan="$(ioc):CA_MAX_ARRAY"
+		chan="$(ioc):CA_MAX_ARRAY_BYTES"
 		clr=14
 		bclr=4
 	}
@@ -342,7 +342,7 @@ text {
 		height=15
 	}
 	monitor {
-		chan="$(ioc):CA_CONN_TIME"
+		chan="$(ioc):CA_CONN_TMO"
 		clr=14
 		bclr=4
 	}
@@ -358,7 +358,7 @@ text {
 		height=15
 	}
 	monitor {
-		chan="$(ioc):CA_SRCH_TIME"
+		chan="$(ioc):CA_MAX_SEARCH_PERIOD"
 		clr=14
 		bclr=4
 	}
@@ -374,7 +374,7 @@ text {
 		height=15
 	}
 	monitor {
-		chan="$(ioc):CA_BEAC_TIME"
+		chan="$(ioc):CA_BEACON_PERIOD"
 		clr=14
 		bclr=4
 	}

--- a/op/bob/autoconvert/ioc_stats_epics_env.bob
+++ b/op/bob/autoconvert/ioc_stats_epics_env.bob
@@ -196,7 +196,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #48</name>
-    <pv_name>$(ioc):CA_SRVR_PORT</pv_name>
+    <pv_name>$(ioc):CA_SERVER_PORT</pv_name>
     <x>304</x>
     <y>50</y>
     <width>196</width>
@@ -216,7 +216,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #52</name>
-    <pv_name>$(ioc):CA_RPTR_PORT</pv_name>
+    <pv_name>$(ioc):CA_REPEATER_PORT</pv_name>
     <x>304</x>
     <y>70</y>
     <width>196</width>
@@ -256,7 +256,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #60</name>
-    <pv_name>$(ioc):CA_AUTO_ADDR</pv_name>
+    <pv_name>$(ioc):CA_AUTO_ADDR_LIST</pv_name>
     <x>304</x>
     <y>110</y>
     <width>196</width>
@@ -276,7 +276,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #64</name>
-    <pv_name>$(ioc):CA_MAX_ARRAY</pv_name>
+    <pv_name>$(ioc):CA_MAX_ARRAY_BYTES</pv_name>
     <x>304</x>
     <y>130</y>
     <width>196</width>
@@ -296,7 +296,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #68</name>
-    <pv_name>$(ioc):CA_CONN_TIME</pv_name>
+    <pv_name>$(ioc):CA_CONN_TMO</pv_name>
     <x>304</x>
     <y>150</y>
     <width>196</width>
@@ -316,7 +316,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #72</name>
-    <pv_name>$(ioc):CA_SRCH_TIME</pv_name>
+    <pv_name>$(ioc):CA_MAX_SEARCH_PERIOD</pv_name>
     <x>304</x>
     <y>170</y>
     <width>196</width>
@@ -336,7 +336,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #76</name>
-    <pv_name>$(ioc):CA_BEAC_TIME</pv_name>
+    <pv_name>$(ioc):CA_BEACON_PERIOD</pv_name>
     <x>304</x>
     <y>190</y>
     <width>196</width>

--- a/op/bob/autoconvert/ioc_stats_epics_env.bob
+++ b/op/bob/autoconvert/ioc_stats_epics_env.bob
@@ -144,7 +144,7 @@
   </widget>
   <widget type="label" version="2.0.0">
     <name>text #36</name>
-    <text>EPICS_TIMEZONE</text>
+    <text>EPICS_TZ</text>
     <x>5</x>
     <y>210</y>
     <width>126</width>
@@ -356,7 +356,7 @@
   </widget>
   <widget type="textupdate" version="2.0.0">
     <name>text update #80</name>
-    <pv_name>$(ioc):TIMEZONE</pv_name>
+    <pv_name>$(ioc):TZ</pv_name>
     <x>270</x>
     <y>210</y>
     <width>250</width>

--- a/op/edl/autoconvert/ioc_stats_epics_env.edl
+++ b/op/edl/autoconvert/ioc_stats_epics_env.edl
@@ -297,7 +297,7 @@ x 304
 y 50
 w 196
 h 15
-controlPv "$(ioc):CA_SRVR_PORT"
+controlPv "$(ioc):CA_SERVER_PORT"
 format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -321,7 +321,7 @@ x 304
 y 70
 w 196
 h 15
-controlPv "$(ioc):CA_RPTR_PORT"
+controlPv "$(ioc):CA_REPEATER_PORT"
 format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -369,7 +369,7 @@ x 304
 y 110
 w 196
 h 15
-controlPv "$(ioc):CA_AUTO_ADDR"
+controlPv "$(ioc):CA_AUTO_ADDR_LIST"
 format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -393,7 +393,7 @@ x 304
 y 130
 w 196
 h 15
-controlPv "$(ioc):CA_MAX_ARRAY"
+controlPv "$(ioc):CA_MAX_ARRAY_BYTES"
 format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -417,7 +417,7 @@ x 304
 y 150
 w 196
 h 15
-controlPv "$(ioc):CA_CONN_TIME"
+controlPv "$(ioc):CA_CONN_TMO"
 format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -441,7 +441,7 @@ x 304
 y 170
 w 196
 h 15
-controlPv "$(ioc):CA_SRCH_TIME"
+controlPv "$(ioc):CA_MAX_SEARCH_PERIOD"
 format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "center"
@@ -465,7 +465,7 @@ x 304
 y 190
 w 196
 h 15
-controlPv "$(ioc):CA_BEAC_TIME"
+controlPv "$(ioc):CA_BEACON_PERIOD"
 format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "center"

--- a/op/edl/autoconvert/ioc_stats_epics_env.edl
+++ b/op/edl/autoconvert/ioc_stats_epics_env.edl
@@ -226,7 +226,7 @@ fgColor rgb 0 0 0
 bgColor index 3
 useDisplayBg
 value {
-  "EPICS_TIMEZONE"
+  "EPICS_TZ"
 }
 endObjectProperties
 
@@ -489,7 +489,7 @@ x 270
 y 210
 w 250
 h 15
-controlPv "$(ioc):TIMEZONE"
+controlPv "$(ioc):TZ"
 format "decimal"
 font "helvetica-medium-r-12.0"
 fontAlign "center"

--- a/op/opi/autoconvert/ioc_stats_epics_env.opi
+++ b/op/opi/autoconvert/ioc_stats_epics_env.opi
@@ -476,7 +476,7 @@ $(pv_value)</tooltip>
     </scale_options>
     <scripts />
     <show_scrollbar>false</show_scrollbar>
-    <text>EPICS_TIMEZONE</text>
+    <text>EPICS_TZ</text>
     <tooltip></tooltip>
     <transparent>true</transparent>
     <vertical_alignment>1</vertical_alignment>
@@ -1043,7 +1043,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(ioc):TIMEZONE</pv_name>
+    <pv_name>$(ioc):TZ</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />

--- a/op/opi/autoconvert/ioc_stats_epics_env.opi
+++ b/op/opi/autoconvert/ioc_stats_epics_env.opi
@@ -635,7 +635,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(ioc):CA_SRVR_PORT</pv_name>
+    <pv_name>$(ioc):CA_SERVER_PORT</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />
@@ -686,7 +686,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(ioc):CA_RPTR_PORT</pv_name>
+    <pv_name>$(ioc):CA_REPEATER_PORT</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />
@@ -788,7 +788,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(ioc):CA_AUTO_ADDR</pv_name>
+    <pv_name>$(ioc):CA_AUTO_ADDR_LIST</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />
@@ -839,7 +839,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(ioc):CA_MAX_ARRAY</pv_name>
+    <pv_name>$(ioc):CA_MAX_ARRAY_BYTES</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />
@@ -890,7 +890,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(ioc):CA_CONN_TIME</pv_name>
+    <pv_name>$(ioc):CA_CONN_TMO</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />
@@ -941,7 +941,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(ioc):CA_SRCH_TIME</pv_name>
+    <pv_name>$(ioc):CA_MAX_SEARCH_PERIOD</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />
@@ -992,7 +992,7 @@ $(pv_value)</tooltip>
     <name>Text Update</name>
     <precision>0</precision>
     <precision_from_pv>true</precision_from_pv>
-    <pv_name>$(ioc):CA_BEAC_TIME</pv_name>
+    <pv_name>$(ioc):CA_BEACON_PERIOD</pv_name>
     <pv_value />
     <rotation_angle>0.0</rotation_angle>
     <rules />

--- a/op/ui/autoconvert/ioc_stats_epics_env.ui
+++ b/op/ui/autoconvert/ioc_stats_epics_env.ui
@@ -482,7 +482,7 @@ border-radius: 2px;
                 </color>
             </property>
             <property name="text">
-                <string>EPICS_TIMEZONE</string>
+                <string>EPICS_TZ</string>
             </property>
             <property name="fontScaleMode">
                 <enum>ESimpleLabel::WidthAndHeight</enum>
@@ -1052,7 +1052,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(ioc):TIMEZONE</string>
+                <string>$(ioc):TZ</string>
             </property>
             <property name="foreground">
                 <color alpha="255">

--- a/op/ui/autoconvert/ioc_stats_epics_env.ui
+++ b/op/ui/autoconvert/ioc_stats_epics_env.ui
@@ -620,7 +620,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(ioc):CA_SRVR_PORT</string>
+                <string>$(ioc):CA_SERVER_PORT</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -674,7 +674,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(ioc):CA_RPTR_PORT</string>
+                <string>$(ioc):CA_REPEATER_PORT</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -782,7 +782,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(ioc):CA_AUTO_ADDR</string>
+                <string>$(ioc):CA_AUTO_ADDR_LIST</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -836,7 +836,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(ioc):CA_MAX_ARRAY</string>
+                <string>$(ioc):CA_MAX_ARRAY_BYTES</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -890,7 +890,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(ioc):CA_CONN_TIME</string>
+                <string>$(ioc):CA_CONN_TMO</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -944,7 +944,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(ioc):CA_SRCH_TIME</string>
+                <string>$(ioc):CA_MAX_SEARCH_PERIOD</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -998,7 +998,7 @@ border-radius: 2px;
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(ioc):CA_BEAC_TIME</string>
+                <string>$(ioc):CA_BEACON_PERIOD</string>
             </property>
             <property name="foreground">
                 <color alpha="255">


### PR DESCRIPTION
Hello fellow EPICS engineers,

This PR updates the reference screens to follow the new standard implemented in release 4.0.0. The new standard uses the actual environment variable names (as defined in CONFIG_ENV and CONFIG_SITE_ENV) for the record names. Although most of these screens continue to work due to the compatibility aliases (with the exception of EPICS_TIMEZONE, more on that on the second paragraph), this PR updates the names so the screens follow the new standard and will continue to work after the compatibility aliases are removed from the inclusion by default.

The EPICS_TIMEZONE env var was deprecated with the release of EPICS 3.15.7 (back in 2019). Nevertheless, it wasn't until this commit (8715ab4) in 2023 that the EPICS_TIMEZONE record was removed from the generated db files (and replaced by the EPICS_TZ variable). In the meantime (for those using the latest EPICS and iocStats versions), the record continued to exist, but was not functional. My understanding is that other than for vxWorks, this variable doesn't do much, which is probably why this went unnoticed until now.

P.S.: I don't have access to some of these tools, so I could not test all of them, I simply replaced the record names in those. I believe there shouldn't be any issues from that, but caveat emptor.

P.S.: Also, since screens continue to (for most intents and purposes) work fine, I didn't think this deserved to have an issue in addition to the PR. But if it'd be best to have an issue for internal tracking/changelog purposes, I would be glad to file it as well.