### PR TITLE
Use the typed device support interfaces when available

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -6,6 +6,12 @@ Release Notes for iocStats
 
 ## Unreleased
 
+* Changes by Andrew Johnson:
+  - iocStats now uses the typed device support interfaces introduced in
+    Base 7.0 when built against a Base that provides them, but is still
+    compatible with EPICS Base 3.15 and later. This removes the `DEVSUPFUN`
+    casts, so the code now builds cleanly with newer C/C++ compilers.
+
 ## iocStats-R4-0-1:
 
 ### Bugfixes

--- a/devIocStats/Makefile
+++ b/devIocStats/Makefile
@@ -16,7 +16,7 @@ INC += devIocStatsOSD.h
 
 LIBRARY_IOC = devIocStats
 
-USR_CFLAGS += -DUSE_TYPED_RSET
+USR_CFLAGS += -DUSE_TYPED_RSET -DUSE_TYPED_DSET
 
 devIocStats_LIBS = $(EPICS_BASE_IOC_LIBS)
 devIocStats_SYS_LIBS_solaris = kstat

--- a/devIocStats/devIocStatsAnalog.c
+++ b/devIocStats/devIocStatsAnalog.c
@@ -135,16 +135,21 @@
   (EPICS_VERSION_INT == VERSION_INT(3, 16, 2, 0)) ||                           \
       (EPICS_VERSION_INT >= VERSION_INT(7, 0, 2, 0))
 
-struct aStats {
-  long number;
-  DEVSUPFUN report;
-  DEVSUPFUN init;
-  DEVSUPFUN init_record;
-  DEVSUPFUN get_ioint_info;
-  DEVSUPFUN read_write;
-  DEVSUPFUN special_linconv;
-};
-typedef struct aStats aStats;
+#ifndef HAS_aidset
+typedef struct aidset {
+  dset common;
+  long (*read_ai)(struct aiRecord *prec);
+  long (*special_linconv)(struct aiRecord *prec, int after);
+} aidset;
+#endif
+
+#ifndef HAS_aodset
+typedef struct aodset {
+  dset common;
+  long (*write_ao)(struct aoRecord *prec);
+  long (*special_linconv)(struct aoRecord *prec, int after);
+} aodset;
+#endif
 
 struct pvtArea {
   int index;
@@ -178,15 +183,15 @@ struct scanInfo {
 typedef struct scanInfo scanInfo;
 
 static long ai_init(int pass);
-static long ai_init_record(aiRecord *);
+static long ai_init_record(struct dbCommon *pcommon);
 static long ai_read(aiRecord *);
-static long ai_ioint_info(int cmd, aiRecord *pr, IOSCANPVT *iopvt);
+static long ai_ioint_info(int cmd, struct dbCommon *pcommon, IOSCANPVT *iopvt);
 
 static long ai_clusts_init(int pass);
-static long ai_clusts_init_record(aiRecord *);
+static long ai_clusts_init_record(struct dbCommon *pcommon);
 static long ai_clusts_read(aiRecord *);
 
-static long ao_init_record(aoRecord *pr);
+static long ao_init_record(struct dbCommon *pcommon);
 static long ao_write(aoRecord *);
 
 static void statsFreeBytes(double *);
@@ -283,13 +288,41 @@ static validGetParms statsGetParms[] = {
     {"cbHighQueueOverruns", statsCbHighQOverruns, QUEUE_TYPE},
     {NULL, NULL, 0}};
 
-aStats devAiStats = {6,       NULL, ai_init, ai_init_record, ai_ioint_info,
-                     ai_read, NULL};
+aidset devAiStats = {
+    {
+        6,
+        NULL,
+        ai_init,
+        ai_init_record,
+        ai_ioint_info
+    },
+    ai_read,
+    NULL
+};
 epicsExportAddress(dset, devAiStats);
-aStats devAoStats = {6, NULL, NULL, ao_init_record, NULL, ao_write, NULL};
+aodset devAoStats = {
+    {
+        6,
+        NULL,
+        NULL,
+        ao_init_record,
+        NULL
+    },
+    ao_write,
+    NULL
+};
 epicsExportAddress(dset, devAoStats);
-aStats devAiClusts = {
-    6, NULL, ai_clusts_init, ai_clusts_init_record, NULL, ai_clusts_read, NULL};
+aidset devAiClusts = {
+    {
+        6,
+        NULL,
+        ai_clusts_init,
+        ai_clusts_init_record,
+        NULL
+    },
+    ai_clusts_read,
+    NULL
+};
 epicsExportAddress(dset, devAiClusts);
 
 static memInfo meminfo = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
@@ -480,7 +513,8 @@ static long ai_init(int pass) {
   return 0;
 }
 
-static long ai_clusts_init_record(aiRecord *pr) {
+static long ai_clusts_init_record(struct dbCommon *pcommon) {
+  aiRecord *pr = (aiRecord *) pcommon;
   int elem = 0, size = 0, pool = 0, parms = 0;
   char *parm;
   pvtClustArea *pvt = NULL;
@@ -512,7 +546,8 @@ static long ai_clusts_init_record(aiRecord *pr) {
   return 0;
 }
 
-static long ai_init_record(aiRecord *pr) {
+static long ai_init_record(struct dbCommon *pcommon) {
+  aiRecord *pr = (aiRecord *) pcommon;
   int i;
   char *parm;
   pvtArea *pvt = NULL;
@@ -543,7 +578,8 @@ static long ai_init_record(aiRecord *pr) {
   return 0;
 }
 
-static long ao_init_record(aoRecord *pr) {
+static long ao_init_record(struct dbCommon *pcommon) {
+  aoRecord *pr = (aoRecord *) pcommon;
   int type;
   char *parm;
   pvtArea *pvt = NULL;
@@ -577,7 +613,8 @@ static long ao_init_record(aoRecord *pr) {
   return 2;
 }
 
-static long ai_ioint_info(int cmd, aiRecord *pr, IOSCANPVT *iopvt) {
+static long ai_ioint_info(int cmd, struct dbCommon *pcommon, IOSCANPVT *iopvt) {
+  aiRecord *pr = (aiRecord *) pcommon;
   pvtArea *pvt = (pvtArea *)pr->dpvt;
 
   if (!pvt)

--- a/devIocStats/devIocStatsString.c
+++ b/devIocStats/devIocStatsString.c
@@ -111,15 +111,12 @@
 
 #define MAX_NAME_SIZE (MAX_STRING_SIZE - 1)
 
-struct sStats {
-  long number;
-  DEVSUPFUN report;
-  DEVSUPFUN init;
-  DEVSUPFUN init_record;
-  DEVSUPFUN get_ioint_info;
-  DEVSUPFUN read_stringin;
-};
-typedef struct sStats sStats;
+#ifndef HAS_stringindset
+typedef struct stringindset {
+  dset common;
+  long (*read_stringin)(struct stringinRecord *prec);
+} stringindset;
+#endif
 
 struct pvtArea {
   int index;
@@ -137,11 +134,11 @@ struct validGetStrParms {
 typedef struct validGetStrParms validGetStrParms;
 
 static long stringin_init(int pass);
-static long stringin_init_record(stringinRecord *);
+static long stringin_init_record(struct dbCommon *pcommon);
 static long stringin_read(stringinRecord *);
-static long envvar_init_record(stringinRecord *);
+static long envvar_init_record(struct dbCommon *pcommon);
 static long envvar_read(stringinRecord *);
-static long epics_init_record(stringinRecord *);
+static long epics_init_record(struct dbCommon *pcommon);
 static long epics_read(stringinRecord *);
 
 static void statsSScript1(char *);
@@ -185,11 +182,36 @@ static validGetStrParms statsGetStrParms[] = {
     {"pwd2", statsPwd2, STATIC_TYPE},
     {NULL, NULL, 0}};
 
-sStats devStringinStats = {
-    5, NULL, stringin_init, stringin_init_record, NULL, stringin_read};
-sStats devStringinEnvVar = {5,    NULL,       NULL, envvar_init_record,
-                            NULL, envvar_read};
-sStats devStringinEpics = {5, NULL, NULL, epics_init_record, NULL, epics_read};
+stringindset devStringinStats = {
+    {
+        5,
+        NULL,
+        stringin_init,
+        stringin_init_record,
+        NULL
+    },
+    stringin_read
+};
+stringindset devStringinEnvVar = {
+    {
+        5,
+        NULL,
+        NULL,
+        envvar_init_record,
+        NULL
+    },
+    envvar_read
+};
+stringindset devStringinEpics = {
+    {
+        5,
+        NULL,
+        NULL,
+        epics_init_record,
+        NULL
+    },
+    epics_read
+};
 epicsExportAddress(dset, devStringinStats);
 epicsExportAddress(dset, devStringinEnvVar);
 epicsExportAddress(dset, devStringinEpics);
@@ -215,7 +237,8 @@ static long stringin_init(int pass) {
   return 0;
 }
 
-static long stringin_init_record(stringinRecord *pr) {
+static long stringin_init_record(struct dbCommon *pcommon) {
+  stringinRecord *pr = (stringinRecord *) pcommon;
   int i;
   char *parm;
   pvtArea *pvt = NULL;
@@ -242,7 +265,8 @@ static long stringin_init_record(stringinRecord *pr) {
   return 0; /* success */
 }
 
-static long envvar_init_record(stringinRecord *pr) {
+static long envvar_init_record(struct dbCommon *pcommon) {
+  stringinRecord *pr = (stringinRecord *) pcommon;
   if (pr->inp.type != INST_IO) {
     recGblRecordError(S_db_badField, (void *)pr,
                       "devStringinEnvVar (init_record) Illegal INP field");
@@ -257,11 +281,12 @@ static long envvar_init_record(stringinRecord *pr) {
   return 0; /* success */
 }
 
-static long epics_init_record(stringinRecord *pr) {
+static long epics_init_record(struct dbCommon *pcommon) {
+  stringinRecord *pr = (stringinRecord *) pcommon;
   long status;
   const ENV_PARAM **ppParam = env_param_list;
 
-  status = envvar_init_record(pr);
+  status = envvar_init_record(pcommon);
   if (status)
     return status;
 

--- a/devIocStats/devIocStatsWaveform.c
+++ b/devIocStats/devIocStatsWaveform.c
@@ -75,15 +75,12 @@
 
 #include "devIocStats.h"
 
-struct wStats {
-  long number;
-  DEVSUPFUN report;
-  DEVSUPFUN init;
-  DEVSUPFUN init_record;
-  DEVSUPFUN get_ioint_info;
-  DEVSUPFUN read_waveform;
-};
-typedef struct wStats wStats;
+#ifndef HAS_wfdset
+typedef struct wfdset {
+  dset common;
+  long (*read_wf)(struct waveformRecord *prec);
+} wfdset;
+#endif
 
 struct pvtArea {
   int index;
@@ -101,7 +98,7 @@ struct validGetWfmParms {
 typedef struct validGetWfmParms validGetWfmParms;
 
 static long waveform_init(int pass);
-static long waveform_init_record(waveformRecord *);
+static long waveform_init_record(struct dbCommon *pcommon);
 static long waveform_read(waveformRecord *);
 
 static void statsSScript(char *, size_t);
@@ -116,8 +113,16 @@ static validGetWfmParms statsGetWfmParms[] = {
     {"pwd", statsPwd, STATIC_TYPE},
     {NULL, NULL, 0}};
 
-wStats devWaveformStats = {
-    5, NULL, waveform_init, waveform_init_record, NULL, waveform_read};
+wfdset devWaveformStats = {
+    {
+        5,
+        NULL,
+        waveform_init,
+        waveform_init_record,
+        NULL
+    },
+    waveform_read
+};
 epicsExportAddress(dset, devWaveformStats);
 
 /* ---------------------------------------------------------------------- */
@@ -131,7 +136,8 @@ static long waveform_init(int pass) {
   return 0;
 }
 
-static long waveform_init_record(waveformRecord *pr) {
+static long waveform_init_record(struct dbCommon *pcommon) {
+  waveformRecord *pr = (waveformRecord *) pcommon;
   int i;
   char *parm;
   pvtArea *pvt = NULL;


### PR DESCRIPTION
This removes warnings and errors from recent C & C++ compilers.

Apparently it duplicates #66 (which I only just found) but that PR doesn't include similar changes to the devIocStatsString.c and devIocStatsWaveform.c files that this PR does.

I assumed the oldest Base version supported was 3.15, not sure if this will fail against 3.14 which I haven't tried.

Developed using Claude and a generic plan that I had it create from my drvIpac commits:
- [use-typed-tables-Plan.md](https://github.com/user-attachments/files/28406080/use-typed-tables-Plan.md)
- [use-typed-tables.patch](https://github.com/user-attachments/files/28406091/use-typed-tables.patch)
