### PR TITLE
Drop environment variables from EPICS base that are too long

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -37,6 +37,12 @@
 
 WITH_PVA=$(if $(strip $(EPICS_PVA_MAJOR_VERSION) $(PVXS_MAJOR_VERSION)),YES,NO)
 
+# Variables coming from CONFIG_ENV and CONFIG_SITE_ENV that are
+# longer than this will be dropped when expanding iocAdmin*.db.
+# This should be configured as a site needs depending on their own
+# naming conventions.
+IOCSTATS_MAX_ENV_VAR_LENGTH=40
+
 -include $(SUPPORT)/configure/CONFIG_SITE
 
 # These allow developers to override the CONFIG_SITE variable

--- a/iocAdmin/Db/Makefile
+++ b/iocAdmin/Db/Makefile
@@ -49,4 +49,4 @@ iocAdminVxWorks.db$(DEP): $(SUBST_DEPS)
 $(COMMON_DIR)/siteEnvVars.substitutions: $(EPICS_BASE)/configure/CONFIG_SITE_ENV $(EPICS_BASE)/configure/CONFIG_ENV
 	@echo Expanding siteEnvVars.substitutions from $^....
 	@$(RM) $@
-	@$(PERL) ../genSiteEnvVars.pl $^ > $@
+	@$(PERL) ../genSiteEnvVars.pl -l $(IOCSTATS_MAX_ENV_VAR_LENGTH) $^ > $@

--- a/iocAdmin/Db/genSiteEnvVars.pl
+++ b/iocAdmin/Db/genSiteEnvVars.pl
@@ -1,13 +1,36 @@
 #!/usr/bin/env perl
 #
-# Usage:  genSiteEnvVars.pl CONFIG_SITE_ENV [ ... ]
-#
 # Reads an EPICS CONFIG_SITE_ENV file and outputs
 # a substitutions file to generate appropriate EPICS
 # records for those variables via iocEnvVar.template
 #
+# Will drop environment variables deemed too long as they
+# may produce invalid PV names. This is configured in
+# CONFIG_SITE.
+#
 use strict;
 use warnings;
+
+use File::Basename;
+use Getopt::Std;
+
+my $tool = basename($0);
+
+our ($opt_h, $opt_l);
+
+sub HELP_MESSAGE {
+    print STDERR "Usage: $tool [-h] [-l max_length] <input files>\n";
+    exit 2;
+}
+
+HELP_MESSAGE() if !getopts("hl:") || $opt_h;
+
+my $max_length;
+if ($opt_l) {
+    $max_length = $opt_l;
+} else {
+    $max_length = 15;
+}
 
 print <<__END__;
 file "iocEnvVar.template" {
@@ -24,11 +47,16 @@ my %varcount;
 my @unique_vars = grep { not $varcount{$_}++ } @epics_vars;
 
 foreach (@unique_vars) {
+    if (length($_) > $max_length) {
+        print STDERR "Warning: Variable $_ is potentially too long for a ";
+        print STDERR "PV name given a typical prefix. Skipping.\n";
+        next
+    }
     my $desc = "EPICS_$_";
     if (length($desc) > 40) {
         $desc = substr($desc, 0, 40);
+        print STDERR "Warning: Truncated description for $_ to fit 40 characters: $desc\n";
     }
-    print STDERR "Warning: Truncated description for $_ to fit 40 characters: $desc\n" if $desc ne "EPICS_$_";
     print "{ $_, EPICS_$_, $desc, epics }\n";
 }
 print("}\n");


### PR DESCRIPTION
This is configured in CONFIG_SITE(.local) using the variable `IOCSTATS_MAX_ENV_VAR_LENGTH`; the default is 40, but a given site should tune it for their own PV prefix needs.

Fixes #86.

@anjohnson my perl isn't particularly great, I wouldn't mind a review from you.